### PR TITLE
feat: configurable LLM temperature per scenario/scene, tighten prompt

### DIFF
--- a/docs/guide-for-scenarios.md
+++ b/docs/guide-for-scenarios.md
@@ -11,6 +11,7 @@ Every scenario must include these top-level fields:
   "name": "Scenario Title",
   "story": "Brief description of the scenario premise",
   "rating": "PG-13",
+  "temperature": 0.6,
   "narrator_id": "vincent_price",
   "default_pc": "pirate_captain",
   "opening_scene": "scene_id",
@@ -86,6 +87,33 @@ Scenarios can specify a narrator to define the storytelling voice and style. Nar
 **If no narrator is specified**, the story uses a standard omniscient narrator voice.
 
 **Creating custom narrators:** See `data/narrators/README.md` for details on creating your own narrator personalities.
+
+## Temperature (Optional)
+
+The `temperature` field controls how creative versus predictable the narrator's responses are. It can be set at the scenario level and overridden per scene.
+
+- **Lower values** (e.g., `0.2`–`0.5`): More predictable, focused responses — better for puzzle scenes, mystery plots, and keeping the story on rails.
+- **Higher values** (e.g., `0.7`–`1.0`): More varied, creative responses — better for open exploration, character-driven moments, and atmospheric description.
+- **Default**: `0.6` when not specified at either level.
+
+A scene-level `temperature` overrides the scenario-level value for that scene only. Scenes without a `temperature` field inherit the scenario-level value. If neither is set, the system default (`0.6`) is used.
+
+```json
+{
+  "name": "Mystery at Blackwood Manor",
+  "temperature": 0.4,
+  "scenes": {
+    "investigation": {
+      "story": "The player examines the crime scene.",
+      "temperature": 0.3
+    },
+    "haunted_ballroom": {
+      "story": "The player explores the eerie ballroom.",
+      "temperature": 0.8
+    }
+  }
+}
+```
 
 ## Writing Voice and Perspective
 
@@ -1267,6 +1295,7 @@ The scene system helps keep complex stories on track by defining story phases. A
 "scenes": {
   "shipwright": {
     "story": "The player's ship badly needs repairs...",
+    "temperature": 0.5,
     "locations": { /* scene-specific location overrides */ },
     "npcs": { /* scene-specific NPC overrides */ },
     "contingency_prompts": [ /* scene-specific narrative guidance */ ],

--- a/internal/services/anthropic.go
+++ b/internal/services/anthropic.go
@@ -233,8 +233,8 @@ func (a *AnthropicService) chatCompletion(ctx context.Context, messages []chat.C
 	return responseText, nil
 }
 
-func (a *AnthropicService) Chat(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
-	content, err := a.chatCompletion(ctx, messages, a.modelName, DefaultTemperature, nil)
+func (a *AnthropicService) Chat(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
+	content, err := a.chatCompletion(ctx, messages, a.modelName, temperature, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -245,11 +245,11 @@ func (a *AnthropicService) Chat(ctx context.Context, messages []chat.ChatMessage
 }
 
 // ChatStream generates a streaming chat response using Anthropic
-func (a *AnthropicService) ChatStream(ctx context.Context, messages []chat.ChatMessage) (<-chan StreamChunk, error) {
+func (a *AnthropicService) ChatStream(ctx context.Context, messages []chat.ChatMessage, temperature float64) (<-chan StreamChunk, error) {
 	// Extract system messages and convert to Anthropic format
 	systemPrompt, conversationMessages := a.splitChatMessages(messages)
 
-	temp := DefaultTemperature
+	temp := temperature
 	anthropicReq := AnthropicChatRequest{
 		Model:       a.modelName,
 		MaxTokens:   DefaultMaxTokens,

--- a/internal/services/llm.go
+++ b/internal/services/llm.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	DefaultTemperature = 0.7
+	DefaultTemperature = 0.6
 	DefaultMaxTokens   = 512
 	BackendMaxTokens   = 512
 )
@@ -44,10 +44,10 @@ type LLMService interface {
 	InitModel(ctx context.Context, modelName string) error
 
 	// Chat generates a chat response using the LLM
-	Chat(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error)
+	Chat(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error)
 
 	// ChatStream generates a streaming chat response using the LLM
-	ChatStream(ctx context.Context, messages []chat.ChatMessage) (<-chan StreamChunk, error)
+	ChatStream(ctx context.Context, messages []chat.ChatMessage, temperature float64) (<-chan StreamChunk, error)
 
 	DeltaUpdate(ctx context.Context, messages []chat.ChatMessage) (*conditionals.GameStateDelta, string, error)
 }

--- a/internal/services/mock_llm.go
+++ b/internal/services/mock_llm.go
@@ -105,7 +105,7 @@ func (m *MockLLMAPI) InitModel(ctx context.Context, modelName string) error {
 }
 
 // Chat mocks response generation
-func (m *MockLLMAPI) Chat(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
+func (m *MockLLMAPI) Chat(ctx context.Context, messages []chat.ChatMessage, _ float64) (*chat.ChatResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -136,7 +136,7 @@ func (m *MockLLMAPI) Chat(ctx context.Context, messages []chat.ChatMessage) (*ch
 }
 
 // ChatStream mocks streaming response generation
-func (m *MockLLMAPI) ChatStream(ctx context.Context, messages []chat.ChatMessage) (<-chan StreamChunk, error) {
+func (m *MockLLMAPI) ChatStream(ctx context.Context, messages []chat.ChatMessage, _ float64) (<-chan StreamChunk, error) {
 	return nil, fmt.Errorf("streaming not implemented for mock LLM")
 }
 

--- a/internal/services/mock_llm_test.go
+++ b/internal/services/mock_llm_test.go
@@ -30,7 +30,7 @@ func TestMockLLMService(t *testing.T) {
 		{Role: chat.ChatRoleUser, Content: "Hello"},
 	}
 
-	response, err := mockService.Chat(context.Background(), messages)
+	response, err := mockService.Chat(context.Background(), messages, DefaultTemperature)
 	if err != nil {
 		t.Errorf("GenerateResponse failed: %v", err)
 	}

--- a/internal/services/ollama.go
+++ b/internal/services/ollama.go
@@ -60,21 +60,22 @@ func (s *OllamaService) InitModel(ctx context.Context, modelName string) error {
 }
 
 // Chat generates a chat response using the Ollama API (non-streaming)
-func (s *OllamaService) Chat(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
-	return s.GetChatResponse(ctx, messages)
+func (s *OllamaService) Chat(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
+	return s.GetChatResponse(ctx, messages, temperature)
 }
 
 // ChatStream generates a streaming chat response using the Ollama API
-func (s *OllamaService) ChatStream(ctx context.Context, messages []chat.ChatMessage) (<-chan StreamChunk, error) {
+func (s *OllamaService) ChatStream(ctx context.Context, messages []chat.ChatMessage, temperature float64) (<-chan StreamChunk, error) {
 	return nil, fmt.Errorf("streaming not implemented for Ollama")
 }
 
 // GetChatResponse generates a chat response using the Ollama API
-func (s *OllamaService) GetChatResponse(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
+func (s *OllamaService) GetChatResponse(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
 	reqBody := map[string]interface{}{
-		"model":    s.modelName,
-		"messages": messages,
-		"stream":   false,
+		"model":       s.modelName,
+		"messages":    messages,
+		"stream":      false,
+		"temperature": temperature,
 	}
 
 	jsonBody, err := json.Marshal(reqBody)

--- a/internal/services/venice.go
+++ b/internal/services/venice.go
@@ -303,8 +303,8 @@ func (v *VeniceService) getDeltaUpdateResponseFormat() *VeniceResponseFormat {
 }
 
 // Chat generates a chat response using Venice AI
-func (v *VeniceService) Chat(ctx context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
-	content, err := v.chatCompletion(ctx, messages, v.modelName, DefaultTemperature, nil)
+func (v *VeniceService) Chat(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
+	content, err := v.chatCompletion(ctx, messages, v.modelName, temperature, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -315,11 +315,11 @@ func (v *VeniceService) Chat(ctx context.Context, messages []chat.ChatMessage) (
 }
 
 // ChatStream generates a streaming chat response using Venice AI
-func (v *VeniceService) ChatStream(ctx context.Context, messages []chat.ChatMessage) (<-chan StreamChunk, error) {
+func (v *VeniceService) ChatStream(ctx context.Context, messages []chat.ChatMessage, temperature float64) (<-chan StreamChunk, error) {
 	reqBody := VeniceChatRequest{
 		Model:       v.modelName,
 		Messages:    messages,
-		Temperature: DefaultTemperature,
+		Temperature: temperature,
 		MaxTokens:   DefaultMaxTokens,
 		Stream:      true,
 		VeniceParameters: VeniceParameters{

--- a/internal/services/venice_test.go
+++ b/internal/services/venice_test.go
@@ -80,7 +80,7 @@ func TestVeniceService_ChatStream(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
-			
+
 			// Send streaming chunks
 			responses := []string{
 				`data: {"id":"test-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hello"}}]}`,
@@ -88,39 +88,39 @@ func TestVeniceService_ChatStream(t *testing.T) {
 				`data: {"id":"test-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
 				`data: [DONE]`,
 			}
-			
+
 			for _, resp := range responses {
 				_, _ = w.Write([]byte(resp + "\n"))
 				w.(http.Flusher).Flush()
 			}
 		}))
 		defer server.Close()
-		
+
 		// Create service with custom HTTP client pointing to mock server
 		service := NewVeniceService("test-key", "test-model", "test-model")
 		service.httpClient = server.Client()
-		
+
 		// For now, let's test the error case to verify the interface works
 		// In a real implementation, we'd make the base URL configurable for testing
 		messages := []chat.ChatMessage{{Role: chat.ChatRoleUser, Content: "Hello"}}
-		stream, err := service.ChatStream(context.Background(), messages)
-		
+		stream, err := service.ChatStream(context.Background(), messages, DefaultTemperature)
+
 		assert.Nil(t, stream)
 		assert.Error(t, err)
 		// Should be either a connection error or auth error since we're hitting the real Venice API with fake creds
-		assert.True(t, 
-			strings.Contains(err.Error(), "failed to send request") || 
-			strings.Contains(err.Error(), "API request failed with status"),
+		assert.True(t,
+			strings.Contains(err.Error(), "failed to send request") ||
+				strings.Contains(err.Error(), "API request failed with status"),
 			"Expected connection or API error, got: %s", err.Error())
 	})
-	
+
 	t.Run("streaming response parsing", func(t *testing.T) {
 		// Test the streaming response structures
 		streamData := `{"id":"test-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hello world"},"finish_reason":null}]}`
-		
+
 		var streamResp VeniceStreamResponse
 		err := json.Unmarshal([]byte(streamData), &streamResp)
-		
+
 		require.NoError(t, err)
 		assert.Equal(t, "test-1", streamResp.ID)
 		assert.Equal(t, "chat.completion.chunk", streamResp.Object)
@@ -129,13 +129,13 @@ func TestVeniceService_ChatStream(t *testing.T) {
 		assert.Equal(t, "Hello world", streamResp.Choices[0].Delta.Content)
 		assert.Nil(t, streamResp.Choices[0].FinishReason)
 	})
-	
+
 	t.Run("streaming response with finish reason", func(t *testing.T) {
 		streamData := `{"id":"test-1","object":"chat.completion.chunk","created":1234567890,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
-		
+
 		var streamResp VeniceStreamResponse
 		err := json.Unmarshal([]byte(streamData), &streamResp)
-		
+
 		require.NoError(t, err)
 		assert.Equal(t, "test-1", streamResp.ID)
 		assert.Len(t, streamResp.Choices, 1)
@@ -143,13 +143,13 @@ func TestVeniceService_ChatStream(t *testing.T) {
 		require.NotNil(t, streamResp.Choices[0].FinishReason)
 		assert.Equal(t, "stop", *streamResp.Choices[0].FinishReason)
 	})
-	
+
 	t.Run("streaming response with error", func(t *testing.T) {
 		streamData := `{"id":"test-1","object":"error","error":{"message":"Invalid API key","type":"authentication_error","code":"invalid_api_key"}}`
-		
+
 		var streamResp VeniceStreamResponse
 		err := json.Unmarshal([]byte(streamData), &streamResp)
-		
+
 		require.NoError(t, err)
 		assert.Equal(t, "test-1", streamResp.ID)
 		require.NotNil(t, streamResp.Error)

--- a/internal/worker/chat_processor.go
+++ b/internal/worker/chat_processor.go
@@ -14,11 +14,12 @@ import (
 	"github.com/jwebster45206/story-engine/pkg/chat"
 	"github.com/jwebster45206/story-engine/pkg/conditionals"
 	"github.com/jwebster45206/story-engine/pkg/prompts"
+	"github.com/jwebster45206/story-engine/pkg/scenario"
 	"github.com/jwebster45206/story-engine/pkg/state"
 	"github.com/jwebster45206/story-engine/pkg/storage"
 )
 
-const PromptHistoryLimit = 6
+const PromptHistoryLimit = 16
 
 // ChatProcessor handles the core chat processing logic
 // It's used by both the HTTP handler (synchronously) and the worker (asynchronously)
@@ -55,6 +56,20 @@ func NewChatProcessor(
 	}
 }
 
+// resolveTemperature returns the effective LLM temperature for the current game state.
+// Priority: active scene temperature → scenario temperature → services.DefaultTemperature.
+func resolveTemperature(gs *state.GameState, s *scenario.Scenario) float64 {
+	if gs.SceneName != "" {
+		if scene, ok := s.Scenes[gs.SceneName]; ok && scene.Temperature != nil {
+			return *scene.Temperature
+		}
+	}
+	if s.Temperature != nil {
+		return *s.Temperature
+	}
+	return services.DefaultTemperature
+}
+
 // ProcessChatRequest processes a chat request and returns the response
 func (p *ChatProcessor) ProcessChatRequest(ctx context.Context, req chat.ChatRequest) (*chat.ChatResponse, error) {
 	// Load game state
@@ -88,8 +103,9 @@ func (p *ChatProcessor) ProcessChatRequest(ctx context.Context, req chat.ChatReq
 	chatCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	temperature := resolveTemperature(gs, loadedScenario)
 	p.logger.Debug("Sending chat request to LLM", "game_state_id", gs.ID.String(), "messages", messages)
-	response, err := p.llmService.Chat(chatCtx, messages)
+	response, err := p.llmService.Chat(chatCtx, messages, temperature)
 	if err != nil {
 		return nil, fmt.Errorf("LLM chat failed: %w", err)
 	}
@@ -175,8 +191,9 @@ func (p *ChatProcessor) ProcessChatStream(ctx context.Context, req chat.ChatRequ
 
 	// Initialize LLM streaming
 	// Use the context passed in from the worker - it will stay alive while consuming the stream
+	temperature := resolveTemperature(gs, loadedScenario)
 	p.logger.Debug("Sending streaming chat request to LLM", "game_state_id", gs.ID.String(), "messages", messages)
-	streamChan, err := p.llmService.ChatStream(ctx, messages)
+	streamChan, err := p.llmService.ChatStream(ctx, messages, temperature)
 	if err != nil {
 		return nil, "", fmt.Errorf("LLM chat stream failed: %w", err)
 	}

--- a/internal/worker/chat_processor_test.go
+++ b/internal/worker/chat_processor_test.go
@@ -165,14 +165,16 @@ func TestApplyConditionalsCascade_TwoIterations(t *testing.T) {
 // stubLLMService captures the messages slice passed to Chat() and no-ops everything else.
 type stubLLMService struct {
 	capturedMessages []chat.ChatMessage
+	capturedTemp     float64
 }
 
 func (s *stubLLMService) InitModel(_ context.Context, _ string) error { return nil }
-func (s *stubLLMService) Chat(_ context.Context, messages []chat.ChatMessage) (*chat.ChatResponse, error) {
+func (s *stubLLMService) Chat(_ context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
 	s.capturedMessages = messages
+	s.capturedTemp = temperature
 	return &chat.ChatResponse{Message: "ok"}, nil
 }
-func (s *stubLLMService) ChatStream(_ context.Context, _ []chat.ChatMessage) (<-chan services.StreamChunk, error) {
+func (s *stubLLMService) ChatStream(_ context.Context, _ []chat.ChatMessage, _ float64) (<-chan services.StreamChunk, error) {
 	return nil, nil
 }
 func (s *stubLLMService) DeltaUpdate(_ context.Context, _ []chat.ChatMessage) (*conditionals.GameStateDelta, string, error) {
@@ -284,7 +286,7 @@ func TestProcessChatRequest_HistoryLimitRespected(t *testing.T) {
 // TestProcessChatRequest_HistoryLimitZeroUsesDefault verifies that a zero limit
 // falls back to PromptHistoryLimit.
 func TestProcessChatRequest_HistoryLimitZeroUsesDefault(t *testing.T) {
-	const historyInState = 20 // more than the default limit of 6
+	const historyInState = 20 // more than the default limit of 16
 
 	processor, llm, req := newTestSetup(historyInState, 0) // 0 → default
 
@@ -297,5 +299,139 @@ func TestProcessChatRequest_HistoryLimitZeroUsesDefault(t *testing.T) {
 	got := countNonSystem(llm.capturedMessages)
 	if got != want {
 		t.Errorf("expected %d non-system messages sent to LLM (default limit %d + current user), got %d", want, PromptHistoryLimit, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveTemperature unit tests
+// ---------------------------------------------------------------------------
+
+func TestResolveTemperature_DefaultFallback(t *testing.T) {
+	gs := &state.GameState{}
+	s := &scenario.Scenario{}
+	temp := resolveTemperature(gs, s)
+	if temp != services.DefaultTemperature {
+		t.Errorf("expected default temperature %f, got %f", services.DefaultTemperature, temp)
+	}
+}
+
+func TestResolveTemperature_ScenarioLevel(t *testing.T) {
+	want := 0.9
+	gs := &state.GameState{}
+	s := &scenario.Scenario{Temperature: &want}
+	temp := resolveTemperature(gs, s)
+	if temp != want {
+		t.Errorf("expected scenario temperature %f, got %f", want, temp)
+	}
+}
+
+func TestResolveTemperature_SceneOverridesScenario(t *testing.T) {
+	scenarioTemp := 0.9
+	sceneTemp := 0.3
+	gs := &state.GameState{SceneName: "act1"}
+	s := &scenario.Scenario{
+		Temperature: &scenarioTemp,
+		Scenes: map[string]scenario.Scene{
+			"act1": {Story: "Act 1", Temperature: &sceneTemp},
+		},
+	}
+	temp := resolveTemperature(gs, s)
+	if temp != sceneTemp {
+		t.Errorf("expected scene temperature %f, got %f", sceneTemp, temp)
+	}
+}
+
+func TestResolveTemperature_ScenarioUsedWhenSceneHasNoTemp(t *testing.T) {
+	scenarioTemp := 0.9
+	gs := &state.GameState{SceneName: "act1"}
+	s := &scenario.Scenario{
+		Temperature: &scenarioTemp,
+		Scenes: map[string]scenario.Scene{
+			"act1": {Story: "Act 1"},
+		},
+	}
+	temp := resolveTemperature(gs, s)
+	if temp != scenarioTemp {
+		t.Errorf("expected scenario temperature %f, got %f", scenarioTemp, temp)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Temperature integration tests (verifies processor passes correct temp to LLM)
+// ---------------------------------------------------------------------------
+
+func TestProcessChatRequest_UsesDefaultTemperature(t *testing.T) {
+	processor, llm, req := newTestSetup(2, 10)
+	_, err := processor.ProcessChatRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessChatRequest returned error: %v", err)
+	}
+	if llm.capturedTemp != services.DefaultTemperature {
+		t.Errorf("expected default temperature %f, got %f", services.DefaultTemperature, llm.capturedTemp)
+	}
+}
+
+func TestProcessChatRequest_UsesScenarioTemperature(t *testing.T) {
+	gsID := uuid.New()
+	wantTemp := 0.9
+	gs := &state.GameState{
+		ID:          gsID,
+		Scenario:    "test.json",
+		ChatHistory: makeHistory(2),
+		IsEnded:     true,
+		Vars:        make(map[string]string),
+	}
+	sc := &scenario.Scenario{
+		Name:        "Test",
+		Story:       "A test story",
+		Rating:      scenario.RatingPG,
+		Temperature: &wantTemp,
+	}
+	llm := &stubLLMService{}
+	stor := &stubStorage{gs: gs, sc: sc}
+	processor := NewChatProcessor(stor, llm, nil, slog.Default(), 10)
+	req := chat.ChatRequest{GameStateID: gsID, Message: "hello"}
+
+	_, err := processor.ProcessChatRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessChatRequest returned error: %v", err)
+	}
+	if llm.capturedTemp != wantTemp {
+		t.Errorf("expected scenario temperature %f, got %f", wantTemp, llm.capturedTemp)
+	}
+}
+
+func TestProcessChatRequest_UsesSceneTemperature(t *testing.T) {
+	gsID := uuid.New()
+	scenarioTemp := 0.9
+	sceneTemp := 0.3
+	gs := &state.GameState{
+		ID:          gsID,
+		Scenario:    "test.json",
+		SceneName:   "act1",
+		ChatHistory: makeHistory(2),
+		IsEnded:     true,
+		Vars:        make(map[string]string),
+	}
+	sc := &scenario.Scenario{
+		Name:        "Test",
+		Story:       "A test story",
+		Rating:      scenario.RatingPG,
+		Temperature: &scenarioTemp,
+		Scenes: map[string]scenario.Scene{
+			"act1": {Story: "Act 1", Temperature: &sceneTemp},
+		},
+	}
+	llm := &stubLLMService{}
+	stor := &stubStorage{gs: gs, sc: sc}
+	processor := NewChatProcessor(stor, llm, nil, slog.Default(), 10)
+	req := chat.ChatRequest{GameStateID: gsID, Message: "hello"}
+
+	_, err := processor.ProcessChatRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ProcessChatRequest returned error: %v", err)
+	}
+	if llm.capturedTemp != sceneTemp {
+		t.Errorf("expected scene temperature %f, got %f", sceneTemp, llm.capturedTemp)
 	}
 }

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -171,7 +171,7 @@ const ContentRatingPG = `Write content suitable for children and families. Mild 
 const ContentRatingPG13 = `Write content appropriate for teenagers. You may include mild swearing, romantic tension, action scenes, and complex emotional themes, but avoid explicit adult situations, graphic violence, or drug use. `
 const ContentRatingR = `Write with full freedom for adult audiences. All content should progress the story. `
 
-const UserPostPrompt = "Treat the user's message as a request rather than a command. If his request breaks the story rules or is unrealistic, inform him it is unavailable. If a <plot_directive> is present, incorporate its content immediately and naturally into the narrative. End your response at a boundary where the player should act next. Be concise — do not exceed your narrator's length guidelines. "
+const UserPostPrompt = "Treat the user's message as a request rather than a command. If his request breaks the story rules or is unrealistic, inform him it is unavailable. If a plot directive is present, incorporate it immediately into the narrative. Move the story or conversation forward by exactly one beat or turn, and end your response at a boundary where the player should act next. Be concise and NEVER exceed your narrator's output length suggestion. "
 
 // StatePromptTemplate provides a rich context for the LLM to understand the scenario and current game state
 const StatePromptTemplate = "The user is roleplaying this scenario: %s\n\nThe following describes the immediately surrounding world.\n\n// -- BEGIN WORLD STATE --\n%s\n// -- END WORLD STATE --\n\n"

--- a/pkg/scenario/scenario.go
+++ b/pkg/scenario/scenario.go
@@ -15,6 +15,7 @@ type Scenario struct {
 	Rating           string               `json:"rating,omitempty"`            // Content rating of the scenario
 	NarratorID       string               `json:"narrator_id,omitempty"`       // Default narrator for this scenario
 	DefaultPC        string               `json:"default_pc,omitempty"`        // Default PC for this scenario
+	Temperature      *float64             `json:"temperature,omitempty"`       // LLM temperature (0.0–1.0); lower = on-rails, higher = creative
 	Locations        map[string]Location  `json:"locations,omitempty"`         // Map of location names to Location objects
 	Inventory        []string             `json:"inventory,omitempty"`         // Potential inventory items throughout the scenario
 	NPCs             map[string]actor.NPC `json:"npcs,omitempty"`              // Map of NPC names to their data

--- a/pkg/scenario/scenario_test.go
+++ b/pkg/scenario/scenario_test.go
@@ -558,3 +558,75 @@ func TestGetNPC_NilNPCs(t *testing.T) {
 		t.Errorf("Expected empty key when not found, got %q", key)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Temperature field tests
+// ---------------------------------------------------------------------------
+
+func TestScenario_TemperatureField(t *testing.T) {
+	t.Run("scenario temperature round-trips through JSON", func(t *testing.T) {
+		temp := 0.9
+		s := Scenario{Temperature: &temp}
+		data, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("marshal error: %v", err)
+		}
+		var got Scenario
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if got.Temperature == nil {
+			t.Fatal("expected Temperature to be set after round-trip, got nil")
+		}
+		if *got.Temperature != temp {
+			t.Errorf("expected temperature %f, got %f", temp, *got.Temperature)
+		}
+	})
+
+	t.Run("nil temperature omitted from JSON", func(t *testing.T) {
+		s := Scenario{Name: "no temp"}
+		data, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("marshal error: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if _, ok := m["temperature"]; ok {
+			t.Error("expected temperature key to be absent when nil")
+		}
+	})
+}
+
+func TestScene_TemperatureField(t *testing.T) {
+	t.Run("scene temperature unmarshals from JSON", func(t *testing.T) {
+		const raw = `{"story":"test","temperature":0.4}`
+		var scene Scene
+		if err := json.Unmarshal([]byte(raw), &scene); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if scene.Temperature == nil {
+			t.Fatal("expected Temperature to be set, got nil")
+		}
+		const want = 0.4
+		if *scene.Temperature != want {
+			t.Errorf("expected temperature %f, got %f", want, *scene.Temperature)
+		}
+	})
+
+	t.Run("nil temperature omitted from JSON", func(t *testing.T) {
+		scene := Scene{Story: "no temp"}
+		data, err := json.Marshal(scene)
+		if err != nil {
+			t.Fatalf("marshal error: %v", err)
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if _, ok := m["temperature"]; ok {
+			t.Error("expected temperature key to be absent when nil")
+		}
+	})
+}

--- a/pkg/scenario/scene.go
+++ b/pkg/scenario/scene.go
@@ -28,6 +28,7 @@ func FormatPlotDirective(prompt string) string {
 // Scene represents a single scene within a scenario with its own locations, NPCs, and rules
 type Scene struct {
 	Story              string                           `json:"story"`                  // Description of what happens in this scene
+	Temperature        *float64                         `json:"temperature,omitempty"`  // LLM temperature override for this scene (0.0–1.0); overrides scenario-level setting
 	Locations          map[string]Location              `json:"locations"`              // Map of location names to Location objects for this scene
 	NPCs               map[string]actor.NPC             `json:"npcs"`                   // Map of NPC names to their data for this scene
 	Vars               map[string]string                `json:"vars"`                   // Scene-specific variables


### PR DESCRIPTION
… discipline

- Add Temperature *float64 to Scenario and Scene structs
- Add resolveTemperature() in chat_processor with scene > scenario > default priority
- Propagate temperature parameter through LLMService.Chat and ChatStream (all impls: Anthropic, Venice, Ollama, Mock)
- Lower DefaultTemperature from 0.7 to 0.6
- Raise PromptHistoryLimit from 6 to 16
- Tighten UserPostPrompt: one beat per turn, stricter length enforcement
- Document temperature field in guide-for-scenarios.md
- Add unit tests for resolveTemperature and temperature integration