### PR TITLE
Allow CONFIG and DATA_DIR overrides via docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,31 @@ Create a JSON configuration file with your service settings:
 ### API Server
 
 ```bash
-GAME_CONFIG=config.json go run cmd/api/main.go
+CONFIG=config.json go run ./cmd/api
+```
+
+The worker uses the same env var:
+
+```bash
+CONFIG=config.json go run ./cmd/worker
+```
+
+### Docker
+
+Override the host data directory and/or config file when starting compose. Host `CONFIG` is mounted at `/app/config.json` inside the container; the container always reads that path.
+
+```bash
+# Default: ./data and ./config.docker.json
+docker compose up
+
+# Custom data dir and config
+DATA_DIR=/path/to/data CONFIG=/somewhere.json docker compose up
+
+# Override only data
+DATA_DIR=/path/to/my-data docker compose up
+
+# Override only config
+CONFIG=./config.venice.json docker compose up
 ```
 
 ### Console Client

--- a/README.md
+++ b/README.md
@@ -184,12 +184,6 @@ docker compose up
 
 # Custom data dir and config
 DATA_DIR=/path/to/data CONFIG=/somewhere.json docker compose up
-
-# Override only data
-DATA_DIR=/path/to/my-data docker compose up
-
-# Override only config
-CONFIG=./config.venice.json docker compose up
 ```
 
 ### Console Client

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -28,6 +28,7 @@ func main() {
 	log := logger.Setup(cfg)
 
 	log.Info("Starting Story Engine API",
+		"config", os.Getenv("CONFIG"),
 		"port", cfg.Port,
 		"environment", cfg.Environment,
 		"llm_provider", cfg.LLMProvider,

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -27,6 +27,7 @@ func main() {
 	log := logger.Setup(cfg)
 
 	log.Info("Starting Story Engine Worker",
+		"config", os.Getenv("CONFIG"),
 		"environment", cfg.Environment,
 		"redis_url", cfg.RedisURL)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - "8080:8080"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ./config.docker.json:/app/config.docker.json
+      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
     environment:
-      - GAME_CONFIG=/app/config.docker.json
+      - CONFIG=/app/config.json
     depends_on:
       - redis
     healthcheck:
@@ -30,9 +30,9 @@ services:
     command: ["./worker"]  # Override CMD
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ./config.docker.json:/app/config.docker.json
+      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
     environment:
-      - GAME_CONFIG=/app/config.docker.json
+      - CONFIG=/app/config.json
       - WORKER_ID=worker-1
     depends_on:
       - redis

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,14 +23,13 @@ type Config struct {
 	ChatHistoryLimit int        `json:"chat_history_limit"` // max number of past messages sent to LLM per request (0 = use default)
 }
 
+// Load reads configuration from the CONFIG environment variable.
 func Load() (*Config, error) {
-
-	configFile := getEnv("GAME_CONFIG", "")
+	configFile := getEnv("CONFIG", "")
 	if configFile == "" {
-		return nil, fmt.Errorf("GAME_CONFIG environment variable is not set")
+		return nil, fmt.Errorf("CONFIG environment variable is not set")
 	}
 
-	// Read config file
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %v", configFile, err)
@@ -41,7 +40,6 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file %s: %v", configFile, err)
 	}
 
-	// Parse log level from string
 	config.LogLevel = parseLogLevel(config.LogLevelStr)
 	return &config, nil
 }

--- a/internal/services/anthropic.go
+++ b/internal/services/anthropic.go
@@ -284,8 +284,12 @@ func (a *AnthropicService) ChatStream(ctx context.Context, messages []chat.ChatM
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("API request failed with status: %d", resp.StatusCode)
+		if readErr != nil {
+			return nil, fmt.Errorf("API request failed with status %d (also failed to read body: %w)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	chunkChan := make(chan StreamChunk, 10)

--- a/internal/services/venice.go
+++ b/internal/services/venice.go
@@ -347,8 +347,12 @@ func (v *VeniceService) ChatStream(ctx context.Context, messages []chat.ChatMess
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("API request failed with status: %d", resp.StatusCode)
+		if readErr != nil {
+			return nil, fmt.Errorf("API request failed with status %d (also failed to read body: %w)", resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	chunkChan := make(chan StreamChunk, 10)


### PR DESCRIPTION
## Summary
- Rename `GAME_CONFIG` to `CONFIG` for the app and compose env var
- Mount host `CONFIG` (default `./config.docker.json`) to a fixed `/app/config.json` path in the container
- Document `DATA_DIR` and `CONFIG` overrides for local and Docker startup

## Test plan
- [ ] `CONFIG=config.json go run ./cmd/api` starts with the local config
- [ ] `docker compose up` still works with default `./data` and `./config.docker.json`
- [ ] `CONFIG=./config.venice.json docker compose up` loads the Venice config in api and worker
- [ ] `DATA_DIR=/path/to/data docker compose up` serves scenarios from the custom data dir


Made with [Cursor](https://cursor.com)