### PR TITLE
fix: align space integ seeds with engineering_bay

### DIFF
--- a/integration/cases/space_min_scene_turns.json
+++ b/integration/cases/space_min_scene_turns.json
@@ -4,7 +4,7 @@
   "seed_game_state": {
     "scenario": "space_disaster.json",
     "scene_name": "min_scene_turns",
-    "user_location": "Test Room",
+    "user_location": "engineering_bay",
     "turn_counter": 5,
     "scene_turn_counter": 0,
     "user_inventory": [],

--- a/integration/cases/space_min_turns.json
+++ b/integration/cases/space_min_turns.json
@@ -4,14 +4,14 @@
   "seed_game_state": {
     "scenario": "space_disaster.json",
     "scene_name": "min_turns",
-    "user_location": "Test Room",
+    "user_location": "engineering_bay",
     "turn_counter": 8,
     "scene_turn_counter": 1,
     "user_inventory": [],
     "chat_history": [
       {
         "role": "assistant",
-        "content": "You've been dealing with this crisis for a while now. The minutes tick by slowly as you assess your options in the test room."
+        "content": "You've been dealing with this crisis for a while now. The minutes tick by slowly as you assess your options in the engineering bay."
       }
     ]
   },

--- a/integration/cases/space_scene_counter.json
+++ b/integration/cases/space_scene_counter.json
@@ -4,14 +4,14 @@
   "seed_game_state": {
     "scenario": "space_disaster.json",
     "scene_name": "scene_counter",
-    "user_location": "Test Room",
+    "user_location": "engineering_bay",
     "turn_counter": 1,
     "scene_turn_counter": 1,
     "user_inventory": [],
     "chat_history": [
       {
         "role": "assistant",
-        "content": "The airlock hisses as emergency lights flicker overhead. You're in a simple test chamber aboard the station. The situation is tense but manageable - for now."
+        "content": "The airlock hisses as emergency lights flicker overhead. You're in the engineering bay aboard the station. The situation is tense but manageable - for now."
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Update space counter integ cases to seed `user_location: engineering_bay` instead of the obsolete `Test Room`
- Align seed chat text with the real scenario location

## Test plan
- [ ] `go test -v -tags=integration ./integration/ -run TestSingleSuite -case space_counters_all`
- [ ] Confirm worker logs no longer warn `Could not find location` with `Test Room` during those cases


Made with [Cursor](https://cursor.com)