### PR TITLE
fix: default CONFIG in compose so down works without it

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,22 @@ CONFIG=config.json go run ./cmd/worker
 
 ### Docker Compose
 
-Pass a host config file via `CONFIG` (mounted read-only at `/app/config.json`) and optionally override scenario data with `DATA_DIR`:
+Defaults to `./data` and `./config.docker.json`. Override either when starting compose. Host `CONFIG` is mounted read-only at `/app/config.json`:
 
 ```bash
+# Default
+docker compose up --build -d
+
+# Custom data dir and config
 DATA_DIR=~/Documents/story-engine-scenarios \
 CONFIG=./config.venice.json \
 docker compose up --build -d
 ```
 
-`CONFIG` is required. Edit the mounted config on the host, then restart without rebuilding:
+Edit the mounted config on the host, then recreate the containers so the mount picks up the change (a plain `restart` can keep a stale file bind):
 
 ```bash
-docker compose restart story-engine-api story-engine-worker
+docker compose up -d --force-recreate story-engine-api story-engine-worker
 ```
 
 Use `redis:6379` as `redis_url` in Docker configs (the compose Redis service hostname).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8080:8080"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ${CONFIG:?Set CONFIG to a host config JSON path}:/app/config.json:ro
+      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
     environment:
       - CONFIG=/app/config.json
     depends_on:
@@ -30,7 +30,7 @@ services:
     command: ["./worker"]  # Override CMD
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ${CONFIG:?Set CONFIG to a host config JSON path}:/app/config.json:ro
+      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
     environment:
       - CONFIG=/app/config.json
       - WORKER_ID=worker-1


### PR DESCRIPTION
## Summary
- Replace required `${CONFIG:?...}` with `${CONFIG:-./config.docker.json}` so `docker compose down` works when `CONFIG` is unset
- Update README: CONFIG is optional; use `--force-recreate` after editing a mounted config file

## Test plan
- [ ] `docker compose down` succeeds without `CONFIG` set
- [ ] `docker compose up` uses `./config.docker.json` by default
- [ ] `CONFIG=./config.venice.json docker compose up` still mounts the override


Made with [Cursor](https://cursor.com)