### PR TITLE
fix: omit is_story_event from LLM provider payloads

### DIFF
--- a/internal/services/anthropic.go
+++ b/internal/services/anthropic.go
@@ -44,7 +44,7 @@ type AnthropicToolChoice struct {
 type AnthropicChatRequest struct {
 	Model         string               `json:"model"`
 	MaxTokens     int                  `json:"max_tokens"`
-	Messages      []chat.ChatMessage   `json:"messages"`
+	Messages      []chat.LLMMessage    `json:"messages"`
 	System        string               `json:"system,omitempty"`
 	Stream        bool                 `json:"stream,omitempty"`
 	StopSequences []string             `json:"stop_sequences,omitempty"`
@@ -154,7 +154,7 @@ func (a *AnthropicService) chatCompletion(ctx context.Context, messages []chat.C
 	anthropicReq := AnthropicChatRequest{
 		Model:     modelName,
 		MaxTokens: maxTokens,
-		Messages:  conversationMessages,
+		Messages:  chat.ToLLMMessages(conversationMessages),
 		Stream:    false,
 	}
 
@@ -254,7 +254,7 @@ func (a *AnthropicService) ChatStream(ctx context.Context, messages []chat.ChatM
 	anthropicReq := AnthropicChatRequest{
 		Model:     a.modelName,
 		MaxTokens: DefaultMaxTokens,
-		Messages:  conversationMessages,
+		Messages:  chat.ToLLMMessages(conversationMessages),
 		Stream:    true,
 	}
 

--- a/internal/services/anthropic_test.go
+++ b/internal/services/anthropic_test.go
@@ -115,9 +115,9 @@ func TestAnthropicChatRequestStructure(t *testing.T) {
 	req := AnthropicChatRequest{
 		Model:     "claude-opus-4-7",
 		MaxTokens: 1024,
-		Messages: []chat.ChatMessage{
-			{Role: "user", Content: "Hello"},
-		},
+		Messages: chat.ToLLMMessages([]chat.ChatMessage{
+			{Role: "user", Content: "Hello", IsStoryEvent: true},
+		}),
 		System: "You are a helpful assistant.",
 		Stream: true,
 	}
@@ -146,6 +146,20 @@ func TestAnthropicChatRequestStructure(t *testing.T) {
 		if _, ok := m[key]; !ok {
 			t.Errorf("expected key %q in Anthropic request payload", key)
 		}
+	}
+
+	var msgs []map[string]any
+	if err := json.Unmarshal(m["messages"], &msgs); err != nil {
+		t.Fatalf("Failed to unmarshal messages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if _, ok := msgs[0]["is_story_event"]; ok {
+		t.Errorf("is_story_event must not appear in Anthropic request messages")
+	}
+	if msgs[0]["role"] != "user" || msgs[0]["content"] != "Hello" {
+		t.Errorf("unexpected message payload: %#v", msgs[0])
 	}
 }
 

--- a/internal/services/ollama.go
+++ b/internal/services/ollama.go
@@ -73,7 +73,7 @@ func (s *OllamaService) ChatStream(ctx context.Context, messages []chat.ChatMess
 func (s *OllamaService) GetChatResponse(ctx context.Context, messages []chat.ChatMessage, temperature float64) (*chat.ChatResponse, error) {
 	reqBody := map[string]interface{}{
 		"model":       s.modelName,
-		"messages":    messages,
+		"messages":    chat.ToLLMMessages(messages),
 		"stream":      false,
 		"temperature": temperature,
 	}

--- a/internal/services/venice.go
+++ b/internal/services/venice.go
@@ -47,7 +47,7 @@ type VeniceParameters struct {
 // VeniceChatRequest represents the request structure for Venice AI chat completions
 type VeniceChatRequest struct {
 	Model            string                `json:"model"`
-	Messages         []chat.ChatMessage    `json:"messages"`
+	Messages         []chat.LLMMessage     `json:"messages"`
 	Temperature      float64               `json:"temperature,omitempty"`
 	MaxTokens        int                   `json:"max_tokens,omitempty"`
 	Stream           bool                  `json:"stream"`
@@ -133,7 +133,7 @@ func (v *VeniceService) chatCompletion(ctx context.Context, messages []chat.Chat
 	}
 	veniceReq := VeniceChatRequest{
 		Model:       modelName,
-		Messages:    messages,
+		Messages:    chat.ToLLMMessages(messages),
 		Temperature: temperature,
 		MaxTokens:   maxTokens,
 		Stream:      false,
@@ -318,7 +318,7 @@ func (v *VeniceService) Chat(ctx context.Context, messages []chat.ChatMessage, t
 func (v *VeniceService) ChatStream(ctx context.Context, messages []chat.ChatMessage, temperature float64) (<-chan StreamChunk, error) {
 	reqBody := VeniceChatRequest{
 		Model:       v.modelName,
-		Messages:    messages,
+		Messages:    chat.ToLLMMessages(messages),
 		Temperature: temperature,
 		MaxTokens:   DefaultMaxTokens,
 		Stream:      true,

--- a/internal/services/venice_test.go
+++ b/internal/services/venice_test.go
@@ -49,13 +49,13 @@ func TestVeniceService_InitModel(t *testing.T) {
 // Mock test for chat response structure
 func TestVeniceChatRequestStructure(t *testing.T) {
 	messages := []chat.ChatMessage{
-		{Role: "user", Content: "Hello"},
+		{Role: "user", Content: "Hello", IsStoryEvent: true},
 		{Role: "assistant", Content: "Hi there!"},
 	}
 
 	req := VeniceChatRequest{
 		Model:       "test-model",
-		Messages:    messages,
+		Messages:    chat.ToLLMMessages(messages),
 		Temperature: 0.7,
 		MaxTokens:   1000,
 		Stream:      false,
@@ -71,6 +71,14 @@ func TestVeniceChatRequestStructure(t *testing.T) {
 
 	if req.Temperature != 0.7 {
 		t.Errorf("Expected temperature 0.7, got %f", req.Temperature)
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+	if strings.Contains(string(data), "is_story_event") {
+		t.Errorf("is_story_event must not appear in Venice request payload: %s", data)
 	}
 }
 

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -32,13 +32,27 @@ const (
 	ChatRoleSystem = "system"    // System messages
 )
 
-// ChatMessage represents a single chat message in the conversation
-// This interface is defined by Ollama's API and is used to structure messages
-// sent to the LLM.
+// ChatMessage represents a single chat message in the conversation.
+// IsStoryEvent is persisted/API metadata and must not be sent to LLM providers.
 type ChatMessage struct {
 	Role         string `json:"role"` // "user", "assistant", "system"
 	Content      string `json:"content"`
 	IsStoryEvent bool   `json:"is_story_event,omitempty"` // True if this message is a story event injected by the engine
+}
+
+// LLMMessage is the role/content-only payload accepted by LLM provider APIs.
+type LLMMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ToLLMMessages maps chat history to provider-safe messages (role + content only).
+func ToLLMMessages(msgs []ChatMessage) []LLMMessage {
+	out := make([]LLMMessage, len(msgs))
+	for i, m := range msgs {
+		out[i] = LLMMessage{Role: m.Role, Content: m.Content}
+	}
+	return out
 }
 
 func (cr *ChatRequest) Validate() error {

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -33,7 +33,6 @@ const (
 )
 
 // ChatMessage represents a single chat message in the conversation.
-// IsStoryEvent is persisted/API metadata and must not be sent to LLM providers.
 type ChatMessage struct {
 	Role         string `json:"role"` // "user", "assistant", "system"
 	Content      string `json:"content"`

--- a/pkg/chat/llm_message_test.go
+++ b/pkg/chat/llm_message_test.go
@@ -1,0 +1,29 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestToLLMMessagesOmitsStoryEventMetadata(t *testing.T) {
+	msgs := []ChatMessage{
+		{Role: ChatRoleUser, Content: "story prompt", IsStoryEvent: true},
+		{Role: ChatRoleAgent, Content: "narrator reply"},
+	}
+
+	llmMsgs := ToLLMMessages(msgs)
+	if len(llmMsgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(llmMsgs))
+	}
+	if llmMsgs[0].Role != ChatRoleUser || llmMsgs[0].Content != "story prompt" {
+		t.Errorf("unexpected first message: %#v", llmMsgs[0])
+	}
+
+	data, err := json.Marshal(llmMsgs)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if string(data) != `[{"role":"user","content":"story prompt"},{"role":"assistant","content":"narrator reply"}]` {
+		t.Errorf("unexpected JSON: %s", data)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `chat.LLMMessage` / `ToLLMMessages` for role+content-only LLM wire format
- Anthropic, Venice, and Ollama requests now use that mapping so `is_story_event` is not sent to providers
- Keep `is_story_event` on persisted/API `ChatMessage` for integ tests and clients

## Test plan
- [x] `go test ./pkg/chat/ ./internal/services/`
- [ ] `go test -v -tags=integration ./integration/ -run TestSingleSuite -case story_event_var_trigger` against Anthropic
- [ ] Confirm chats after a story event no longer 400 with `messages.N.is_story_event: Extra inputs are not permitted`


Made with [Cursor](https://cursor.com)