### PR TITLE
fix: salvage truncated gamestate delta JSON

### DIFF
--- a/docs/venice-models.json
+++ b/docs/venice-models.json
@@ -1,8 +1,617 @@
 {
     "data": [
         {
-            "created": 1742262554,
-            "id": "venice-uncensored",
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "gemini-3-6-flash",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.875,
+                        "diem": 1.875
+                    },
+                    "cache_input": {
+                        "usd": 0.1875,
+                        "diem": 0.1875
+                    },
+                    "output": {
+                        "usd": 9.375,
+                        "diem": 9.375
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": true,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemini 3.6 Flash is a high speed, high value thinking model with 1M context, designed for agentic workflows, multi-turn chat, and coding assistance. It delivers near Pro level reasoning with substantially lower latency.",
+                "name": "Gemini 3.6 Flash",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "gemini-3-5-flash-lite",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.375,
+                        "diem": 0.375
+                    },
+                    "cache_input": {
+                        "usd": 0.0375,
+                        "diem": 0.0375
+                    },
+                    "output": {
+                        "usd": 3.125,
+                        "diem": 3.125
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": true,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemini 3.5 Flash-Lite is the fastest, most cost-efficient Gemini 3.5 model with 1M context, ideal for everyday questions, summarization, and lightweight coding tasks.",
+                "name": "Gemini 3.5 Flash-Lite",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1781568000,
+            "id": "zai-org-glm-5-2",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.4,
+                        "diem": 1.4
+                    },
+                    "cache_input": {
+                        "usd": 0.26,
+                        "diem": 0.26
+                    },
+                    "output": {
+                        "usd": 4.4,
+                        "diem": 4.4
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 131072,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "high",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "max",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-5.2 is the next-generation large language model developed by Zhiyuan AI, featuring significantly enhanced reasoning capabilities, improved instruction following, and support for multiple languages. Supports large context windows for processing extensive text and detailed analysis with fast inference speed.",
+                "name": "GLM 5.2",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5.2",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 200000,
+            "created": 1775520000,
+            "id": "zai-org-glm-5-1",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.54,
+                        "diem": 1.54
+                    },
+                    "cache_input": {
+                        "usd": 0.286,
+                        "diem": 0.286
+                    },
+                    "output": {
+                        "usd": 4.84,
+                        "diem": 4.84
+                    }
+                },
+                "availableContextTokens": 200000,
+                "maxCompletionTokens": 80000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-5.1 is the next-generation large language model developed by Zhiyuan AI, featuring significantly enhanced reasoning capabilities, improved instruction following, and support for multiple languages. Supports large context windows for processing extensive text and detailed analysis with fast inference speed.",
+                "name": "GLM 5.1",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5.1",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 198000,
+            "created": 1770768000,
+            "id": "zai-org-glm-5",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1,
+                        "diem": 1
+                    },
+                    "cache_input": {
+                        "usd": 0.2,
+                        "diem": 0.2
+                    },
+                    "output": {
+                        "usd": 3.2,
+                        "diem": 3.2
+                    }
+                },
+                "availableContextTokens": 198000,
+                "maxCompletionTokens": 32000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-5 is the next-generation large language model developed by Zhiyuan AI, featuring significantly enhanced reasoning capabilities, improved instruction following, and support for multiple languages. Supports large context windows for processing extensive text and detailed analysis.",
+                "name": "GLM 5",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 200000,
+            "created": 1773532800,
+            "id": "z-ai-glm-5-turbo",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.2,
+                        "diem": 1.2
+                    },
+                    "cache_input": {
+                        "usd": 0.24,
+                        "diem": 0.24
+                    },
+                    "output": {
+                        "usd": 4,
+                        "diem": 4
+                    }
+                },
+                "availableContextTokens": 200000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-5 Turbo is a fast inference model from Z.ai tuned for strong performance in agent-driven environments and production coding workflows.",
+                "name": "GLM 5 Turbo",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 200000,
+            "created": 1775001600,
+            "id": "z-ai-glm-5v-turbo",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.5,
+                        "diem": 1.5
+                    },
+                    "cache_input": {
+                        "usd": 0.3,
+                        "diem": 0.3
+                    },
+                    "output": {
+                        "usd": 5,
+                        "diem": 5
+                    }
+                },
+                "availableContextTokens": 200000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-5V-Turbo is Z.ai's first native multimodal agent foundation model, built for vision-based coding and agent-driven tasks with image, video, and text inputs.",
+                "name": "GLM 5V Turbo",
+                "modelSource": "https://docs.z.ai/guides/vlm/glm-5v-turbo",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 200000,
+            "created": 1770163200,
+            "id": "olafangensan-glm-4.7-flash-heretic",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.07,
+                        "diem": 0.07
+                    },
+                    "cache_input": {
+                        "usd": 0.035,
+                        "diem": 0.035
+                    },
+                    "output": {
+                        "usd": 0.4,
+                        "diem": 0.4
+                    }
+                },
+                "availableContextTokens": 200000,
+                "maxCompletionTokens": 24000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-4.7-Flash-Heretic is an uncensored experimental variant of GLM-4.7-Flash, optimized for creative freedom and unfiltered dialogue with fast inference speed.",
+                "name": "GLM 4.7 Flash Heretic",
+                "modelSource": "https://huggingface.co/Olafangensan/GLM-4.7-Flash-heretic",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1769644800,
+            "id": "zai-org-glm-4.7-flash",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.06,
+                        "diem": 0.06
+                    },
+                    "cache_input": {
+                        "usd": 0.01,
+                        "diem": 0.01
+                    },
+                    "output": {
+                        "usd": 0.4,
+                        "diem": 0.4
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-4.7-Flash is a fast inference variant of GLM-4.7, optimized for speed while maintaining strong reasoning capabilities. Ideal for applications requiring quick responses with good quality.",
+                "name": "GLM 4.7 Flash",
+                "modelSource": "https://huggingface.co/zai-org/GLM-4.7-Flash",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 198000,
+            "created": 1711929600,
+            "id": "zai-org-glm-4.6",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.43,
+                        "diem": 0.43
+                    },
+                    "cache_input": {
+                        "usd": 0.08,
+                        "diem": 0.08
+                    },
+                    "output": {
+                        "usd": 1.75,
+                        "diem": 1.75
+                    }
+                },
+                "availableContextTokens": 198000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp4",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-4.6 is a large language model developed by Zhiyuan AI, featuring strong reasoning capabilities and support for multiple languages. Supports the largest context window for processing extensive text and detailed analysis.",
+                "name": "GLM 4.6",
+                "modelSource": "https://huggingface.co/zai-org/GLM-4.6",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 198000,
+            "created": 1766534400,
+            "id": "zai-org-glm-4.7",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.55,
+                        "diem": 0.55
+                    },
+                    "cache_input": {
+                        "usd": 0.11,
+                        "diem": 0.11
+                    },
+                    "output": {
+                        "usd": 2.65,
+                        "diem": 2.65
+                    }
+                },
+                "availableContextTokens": 198000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp4",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM-4.7 is a large language model developed by Zhiyuan AI, featuring strong reasoning capabilities and support for multiple languages. Supports the largest context window for processing extensive text and detailed analysis.",
+                "name": "GLM 4.7",
+                "modelSource": "https://huggingface.co/zai-org/GLM-4.7",
+                "offline": false,
+                "privacy": "private",
+                "traits": [
+                    "default",
+                    "most_intelligent",
+                    "function_calling_default"
+                ]
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1775001600,
+            "id": "venice-uncensored-1-2",
             "model_spec": {
                 "pricing": {
                     "input": {
@@ -14,27 +623,31 @@
                         "diem": 0.9
                     }
                 },
-                "availableContextTokens": 32000,
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 128000,
                 "maxCompletionTokens": 8192,
                 "capabilities": {
                     "optimizedForCode": false,
                     "quantization": "fp16",
                     "supportsAudioInput": false,
-                    "supportsFunctionCalling": false,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": false,
                     "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
                     "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Designed for maximum creative freedom and authentic interaction. Ideal for open-ended exploration, roleplay, and unfiltered dialogue. Features minimal content restrictions.",
-                "name": "Venice Uncensored 1.1",
+                "description": "Venice Uncensored 1.2 is designed for maximum creative freedom and authentic interaction. Built for open-ended exploration, roleplay, and unfiltered dialogue with improved capabilities over 1.1.",
+                "name": "Venice Uncensored 1.2",
                 "modelSource": "https://huggingface.co/cognitivecomputations/Dolphin-Mistral-24B-Venice-Edition",
                 "offline": false,
                 "privacy": "private",
@@ -47,6 +660,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1771545600,
             "id": "venice-uncensored-role-play",
             "model_spec": {
@@ -92,97 +706,57 @@
             "type": "text"
         },
         {
-            "created": 1711929600,
-            "id": "zai-org-glm-4.6",
+            "context_length": 1000000,
+            "created": 1784678400,
+            "id": "qwen-3-8-max",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.85,
-                        "diem": 0.85
+                        "usd": 2.5,
+                        "diem": 2.5
                     },
                     "cache_input": {
-                        "usd": 0.3,
-                        "diem": 0.3
+                        "usd": 0.3125,
+                        "diem": 0.3125
+                    },
+                    "cache_write": {
+                        "usd": 3.125,
+                        "diem": 3.125
                     },
                     "output": {
-                        "usd": 2.75,
-                        "diem": 2.75
+                        "usd": 7.5,
+                        "diem": 7.5
                     }
                 },
                 "model_sets": [
                     "venice_recommendations"
                 ],
-                "availableContextTokens": 198000,
-                "maxCompletionTokens": 16384,
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 131072,
                 "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp4",
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
                     "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
-                    "supportsTeeAttestation": false,
-                    "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
-                    "supportsWebSearch": true,
-                    "supportsXSearch": false
-                },
-                "description": "GLM-4.6 is a large language model developed by Zhiyuan AI, featuring strong reasoning capabilities and support for multiple languages. Supports the largest context window for processing extensive text and detailed analysis.",
-                "name": "GLM 4.6",
-                "modelSource": "https://huggingface.co/zai-org/GLM-4.6",
-                "offline": false,
-                "privacy": "private",
-                "traits": []
-            },
-            "object": "model",
-            "owned_by": "venice.ai",
-            "type": "text"
-        },
-        {
-            "created": 1770163200,
-            "id": "olafangensan-glm-4.7-flash-heretic",
-            "model_spec": {
-                "pricing": {
-                    "input": {
-                        "usd": 0.14,
-                        "diem": 0.14
-                    },
-                    "output": {
-                        "usd": 0.8,
-                        "diem": 0.8
-                    }
-                },
-                "model_sets": [
-                    "venice_recommendations"
-                ],
-                "availableContextTokens": 200000,
-                "maxCompletionTokens": 24000,
-                "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp8",
-                    "supportsAudioInput": false,
-                    "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
+                    "supportsResponseSchema": false,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "GLM-4.7-Flash-Heretic is an uncensored experimental variant of GLM-4.7-Flash, optimized for creative freedom and unfiltered dialogue with fast inference speed.",
-                "name": "GLM 4.7 Flash Heretic",
-                "modelSource": "https://huggingface.co/Olafangensan/GLM-4.7-Flash-heretic",
+                "description": "Qwen 3.8 Max is Alibaba's flagship 2.4-trillion-parameter MoE model, with major gains over Qwen 3.7 Max in software engineering and office-productivity workflows and strong long-horizon, multi-agent performance. It accepts both text and vision-language input (images and video), operates in thinking mode only, and supports a 1M-token context window.",
+                "name": "Qwen 3.8 Max",
+                "modelSource": "https://www.alibabacloud.com/help/en/model-studio/models",
                 "offline": false,
-                "privacy": "private",
+                "privacy": "anonymized",
                 "traits": []
             },
             "object": "model",
@@ -190,43 +764,139 @@
             "type": "text"
         },
         {
-            "created": 1769644800,
-            "id": "zai-org-glm-4.7-flash",
+            "context_length": 1000000,
+            "created": 1779408000,
+            "id": "qwen-3-7-max",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.125,
-                        "diem": 0.125
+                        "usd": 2.7,
+                        "diem": 2.7
+                    },
+                    "cache_input": {
+                        "usd": 0.27,
+                        "diem": 0.27
+                    },
+                    "cache_write": {
+                        "usd": 3.35,
+                        "diem": 3.35
                     },
                     "output": {
+                        "usd": 8.05,
+                        "diem": 8.05
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen 3.7 Max is the largest model in the Qwen 3.7 series, with deep thinking, function calling, prompt caching, and multimodal input support for images and video. It excels at programming, office and productivity tasks, and long-running autonomous agent workflows.",
+                "name": "Qwen 3.7 Max",
+                "modelSource": "https://www.alibabacloud.com/help/en/model-studio/models",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1780358400,
+            "id": "qwen-3-7-plus",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
                         "usd": 0.5,
                         "diem": 0.5
+                    },
+                    "cache_input": {
+                        "usd": 0.05,
+                        "diem": 0.05
+                    },
+                    "cache_write": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "output": {
+                        "usd": 2,
+                        "diem": 2
+                    },
+                    "extended": {
+                        "context_token_threshold": 256000,
+                        "input": {
+                            "usd": 1.5,
+                            "diem": 1.5
+                        },
+                        "output": {
+                            "usd": 6,
+                            "diem": 6
+                        },
+                        "cache_input": {
+                            "usd": 0.15,
+                            "diem": 0.15
+                        },
+                        "cache_write": {
+                            "usd": 1.875,
+                            "diem": 1.875
+                        }
                     }
                 },
-                "availableContextTokens": 128000,
-                "maxCompletionTokens": 16384,
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
                 "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp8",
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
                     "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "GLM-4.7-Flash is a fast inference variant of GLM-4.7, optimized for speed while maintaining strong reasoning capabilities. Ideal for applications requiring quick responses with good quality.",
-                "name": "GLM 4.7 Flash",
-                "modelSource": "https://huggingface.co/zai-org/GLM-4.7-Flash",
+                "constraints": {
+                    "temperature": {
+                        "default": 0.7
+                    },
+                    "top_p": {
+                        "default": 0.8
+                    }
+                },
+                "description": "Qwen 3.7 Plus is Alibaba's latest flagship reasoning model with exceptional performance across coding, reasoning, and general knowledge tasks. Features mixed reasoning, function calling, and multimodal input support.",
+                "name": "Qwen 3.7 Plus",
+                "modelSource": "https://www.alibabacloud.com/help/en/model-studio/models",
                 "offline": false,
-                "privacy": "private",
+                "privacy": "anonymized",
                 "traits": []
             },
             "object": "model",
@@ -234,48 +904,140 @@
             "type": "text"
         },
         {
-            "created": 1770768000,
-            "id": "zai-org-glm-5",
+            "context_length": 1000000,
+            "created": 1775433600,
+            "id": "qwen-3-6-plus",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "cache_input": {
+                        "usd": 0.0625,
+                        "diem": 0.0625
+                    },
+                    "cache_write": {
+                        "usd": 0.78,
+                        "diem": 0.78
+                    },
+                    "output": {
+                        "usd": 3.75,
+                        "diem": 3.75
+                    },
+                    "extended": {
+                        "context_token_threshold": 256000,
+                        "input": {
+                            "usd": 2.5,
+                            "diem": 2.5
+                        },
+                        "output": {
+                            "usd": 7.5,
+                            "diem": 7.5
+                        },
+                        "cache_input": {
+                            "usd": 0.0625,
+                            "diem": 0.0625
+                        },
+                        "cache_write": {
+                            "usd": 0.78,
+                            "diem": 0.78
+                        }
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "constraints": {
+                    "temperature": {
+                        "default": 0.7
+                    },
+                    "top_p": {
+                        "default": 0.8
+                    }
+                },
+                "description": "Qwen 3.6 Plus Uncensored is Alibaba's latest flagship reasoning model with exceptional performance across coding, reasoning, and general knowledge tasks. Features mixed reasoning, function calling, and multimodal input support.",
+                "name": "Qwen 3.6 Plus Uncensored",
+                "modelSource": "https://www.alibabacloud.com/blog/qwen3-6-plus-towards-real-world-agents_603005",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1776988800,
+            "id": "qwen3-6-27b",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 1,
-                        "diem": 1
-                    },
-                    "cache_input": {
-                        "usd": 0.2,
-                        "diem": 0.2
+                        "usd": 0.325,
+                        "diem": 0.325
                     },
                     "output": {
-                        "usd": 3.2,
-                        "diem": 3.2
+                        "usd": 3.25,
+                        "diem": 3.25
                     }
                 },
-                "model_sets": [
-                    "venice_recommendations"
-                ],
-                "availableContextTokens": 198000,
-                "maxCompletionTokens": 32000,
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
                 "capabilities": {
                     "optimizedForCode": true,
                     "quantization": "fp8",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
                     "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "GLM-5 is the next-generation large language model developed by Zhiyuan AI, featuring significantly enhanced reasoning capabilities, improved instruction following, and support for multiple languages. Supports large context windows for processing extensive text and detailed analysis.",
-                "name": "GLM 5",
-                "modelSource": "https://huggingface.co/zai-org/GLM-5",
+                "constraints": {
+                    "temperature": {
+                        "default": 1
+                    },
+                    "top_p": {
+                        "default": 0.95
+                    }
+                },
+                "description": "The Qwen 3.6 27B native vision-language dense model builds upon the 3.5-27B version, with key improvements in agentic coding capabilities and enhanced STEM reasoning and inference skills. In the vision modality, it demonstrates significant advances in spatial intelligence, object localization, and detection, while video understanding, document OCR, and visual agent capabilities continue to improve steadily.",
+                "name": "Qwen 3.6 27B",
+                "modelSource": "https://qwen.ai/blog?id=qwen3.6-27b",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -285,114 +1047,69 @@
             "type": "text"
         },
         {
-            "created": 1766534400,
-            "id": "zai-org-glm-4.7",
+            "context_length": 256000,
+            "created": 1784505600,
+            "id": "qwen3-6-35b-a3b",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.55,
-                        "diem": 0.55
-                    },
-                    "cache_input": {
-                        "usd": 0.11,
-                        "diem": 0.11
+                        "usd": 0.1,
+                        "diem": 0.1
                     },
                     "output": {
-                        "usd": 2.65,
-                        "diem": 2.65
+                        "usd": 1,
+                        "diem": 1
                     }
                 },
-                "availableContextTokens": 198000,
-                "maxCompletionTokens": 16384,
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
                 "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp4",
-                    "supportsAudioInput": false,
-                    "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
-                    "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
-                    "supportsTeeAttestation": false,
-                    "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
-                    "supportsWebSearch": true,
-                    "supportsXSearch": false
-                },
-                "description": "GLM-4.7 is a large language model developed by Zhiyuan AI, featuring strong reasoning capabilities and support for multiple languages. Supports the largest context window for processing extensive text and detailed analysis.",
-                "name": "GLM 4.7",
-                "modelSource": "https://huggingface.co/zai-org/GLM-4.7",
-                "offline": false,
-                "privacy": "private",
-                "traits": [
-                    "default",
-                    "most_intelligent",
-                    "function_calling_default"
-                ]
-            },
-            "object": "model",
-            "owned_by": "venice.ai",
-            "type": "text"
-        },
-        {
-            "created": 1745903059,
-            "id": "qwen3-4b",
-            "model_spec": {
-                "pricing": {
-                    "input": {
-                        "usd": 0.05,
-                        "diem": 0.05
-                    },
-                    "output": {
-                        "usd": 0.15,
-                        "diem": 0.15
-                    }
-                },
-                "availableContextTokens": 32000,
-                "maxCompletionTokens": 4096,
-                "capabilities": {
-                    "optimizedForCode": false,
+                    "optimizedForCode": true,
                     "quantization": "fp8",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 3,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
                     "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "deprecation": {
-                    "date": "2026-03-29T00:00:00.000Z"
+                "constraints": {
+                    "temperature": {
+                        "default": 1
+                    },
+                    "top_p": {
+                        "default": 0.95
+                    }
                 },
-                "description": "Optimized for speed and efficiency. Best for quick answers, simple queries, and lightweight tasks on mobile or low-latency connections.",
-                "name": "Venice Small",
-                "modelSource": "https://huggingface.co/Qwen/Qwen3-4B",
+                "description": "Qwen 3.6 35B A3B is a fast mixture-of-experts model with 35B total parameters and ~3B active per token. Strong at agentic coding, STEM reasoning, and tool use, with a native 256K context window.",
+                "name": "Qwen 3.6 35B A3B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
                 "offline": false,
                 "privacy": "private",
-                "traits": [
-                    "fastest"
-                ]
+                "traits": []
             },
             "object": "model",
             "owned_by": "venice.ai",
             "type": "text"
         },
         {
+            "context_length": 256000,
             "created": 1772668800,
             "id": "qwen3-5-9b",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.05,
-                        "diem": 0.05
+                        "usd": 0.1,
+                        "diem": 0.1
                     },
                     "output": {
                         "usd": 0.15,
@@ -400,7 +1117,7 @@
                     }
                 },
                 "availableContextTokens": 256000,
-                "maxCompletionTokens": 65536,
+                "maxCompletionTokens": 32768,
                 "capabilities": {
                     "optimizedForCode": false,
                     "quantization": "fp8",
@@ -410,7 +1127,14 @@
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -431,47 +1155,52 @@
             "type": "text"
         },
         {
-            "created": 1742262554,
-            "id": "mistral-31-24b",
+            "context_length": 128000,
+            "created": 1771200000,
+            "id": "qwen3-5-397b-a17b",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.5,
-                        "diem": 0.5
+                        "usd": 0.75,
+                        "diem": 0.75
                     },
                     "output": {
-                        "usd": 2,
-                        "diem": 2
+                        "usd": 4.5,
+                        "diem": 4.5
                     }
                 },
                 "availableContextTokens": 128000,
-                "maxCompletionTokens": 4096,
+                "maxCompletionTokens": 32768,
                 "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp8",
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
+                    "supportsLogProbs": true,
                     "supportsMultipleImages": true,
-                    "maxImages": 10,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
+                    "maxImages": 5,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
+                    "supportsVideoInput": true,
                     "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "deprecation": {
-                    "date": "2026-03-29T00:00:00.000Z"
-                },
-                "description": "Balanced blend of speed and capability. Handles most everyday tasks with reliability, and supports image analysis. Ideal for general use with moderate complexity.",
-                "name": "Venice Medium",
-                "modelSource": "https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+                "description": "Qwen 3.5 is Alibaba flagship reasoning model featuring a 397B parameter Mixture-of-Experts architecture with 17B active parameters. It excels at complex reasoning, coding, and general knowledge tasks.",
+                "name": "Qwen 3.5 397B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
                 "offline": false,
-                "privacy": "private",
+                "privacy": "anonymized",
                 "traits": []
             },
             "object": "model",
@@ -479,41 +1208,66 @@
             "type": "text"
         },
         {
-            "created": 1768435200,
-            "id": "mistral-small-3-2-24b-instruct",
+            "context_length": 256000,
+            "created": 1771977600,
+            "id": "qwen3-5-35b-a3b",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.09375,
-                        "diem": 0.09375
+                        "usd": 0.3125,
+                        "diem": 0.3125
+                    },
+                    "cache_input": {
+                        "usd": 0.15625,
+                        "diem": 0.15625
                     },
                     "output": {
-                        "usd": 0.25,
-                        "diem": 0.25
+                        "usd": 1.25,
+                        "diem": 1.25
                     }
                 },
                 "availableContextTokens": 256000,
                 "maxCompletionTokens": 16384,
                 "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp8",
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
+                    "supportsLogProbs": true,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Mistral Small 3.2 is a 24B parameter model optimized for efficiency and performance. Ideal for general-purpose tasks with balanced speed and capability.",
-                "name": "Mistral Small 3.2 24B Instruct",
-                "modelSource": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+                "constraints": {
+                    "temperature": {
+                        "default": 1
+                    },
+                    "top_p": {
+                        "default": 0.95
+                    },
+                    "repetition_penalty": {
+                        "default": 1
+                    }
+                },
+                "description": "Qwen 3.5 35B A3B is a highly efficient MoE model with 35B total parameters and only 3B active parameters. It surpasses the larger Qwen3-235B-A22B while being 6.7x smaller, excelling at reasoning, coding, and general knowledge tasks.",
+                "name": "Qwen 3.5 35B A3B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -523,6 +1277,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1745903059,
             "id": "qwen3-235b-a22b-thinking-2507",
             "model_spec": {
@@ -543,10 +1298,16 @@
                     "quantization": "fp8",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -569,6 +1330,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1745903059,
             "id": "qwen3-235b-a22b-instruct-2507",
             "model_spec": {
@@ -589,7 +1351,7 @@
                     "quantization": "fp8",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": false,
                     "supportsReasoningEffort": false,
@@ -613,6 +1375,7 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
             "created": 1745903059,
             "id": "qwen3-next-80b",
             "model_spec": {
@@ -633,7 +1396,7 @@
                     "quantization": "fp16",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": false,
                     "supportsReasoningEffort": false,
@@ -657,17 +1420,75 @@
             "type": "text"
         },
         {
-            "created": 1745903059,
-            "id": "qwen3-coder-480b-a35b-instruct",
+            "context_length": 128000,
+            "created": 1768521600,
+            "id": "qwen3-vl-235b-a22b",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.75,
-                        "diem": 0.75
+                        "usd": 0.21,
+                        "diem": 0.21
+                    },
+                    "cache_input": {
+                        "usd": 0.1,
+                        "diem": 0.1
                     },
                     "output": {
-                        "usd": 3,
-                        "diem": 3
+                        "usd": 1.9,
+                        "diem": 1.9
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen3-VL 235B vision-language model with MoE architecture. The most powerful VL model in the Qwen series with superior visual perception, OCR, and multimodal reasoning.",
+                "name": "Qwen3 VL 235B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct",
+                "offline": false,
+                "privacy": "private",
+                "traits": [
+                    "default_vision"
+                ]
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1769472000,
+            "id": "qwen3-coder-480b-a35b-instruct-turbo",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.35,
+                        "diem": 0.35
+                    },
+                    "cache_input": {
+                        "usd": 0.04,
+                        "diem": 0.04
+                    },
+                    "output": {
+                        "usd": 1.5,
+                        "diem": 1.5
                     }
                 },
                 "availableContextTokens": 256000,
@@ -689,9 +1510,9 @@
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Optimized for code.",
-                "name": "Qwen 3 Coder 480b",
-                "modelSource": "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct",
+                "description": "Turbo variant of Qwen3 Coder 480B, optimized for faster inference on code tasks.",
+                "name": "Qwen 3 Coder 480B Turbo",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
                 "offline": false,
                 "privacy": "private",
                 "traits": [
@@ -703,41 +1524,54 @@
             "type": "text"
         },
         {
-            "created": 1758758400,
-            "id": "hermes-3-llama-3.1-405b",
+            "context_length": 256000,
+            "created": 1775088000,
+            "id": "google-gemma-4-26b-a4b-it",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 1.1,
-                        "diem": 1.1
+                        "usd": 0.13,
+                        "diem": 0.13
+                    },
+                    "cache_input": {
+                        "usd": 0.05,
+                        "diem": 0.05
                     },
                     "output": {
-                        "usd": 3,
-                        "diem": 3
+                        "usd": 0.4,
+                        "diem": 0.4
                     }
                 },
-                "availableContextTokens": 128000,
-                "maxCompletionTokens": 16384,
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 8192,
                 "capabilities": {
                     "optimizedForCode": false,
-                    "quantization": "fp8",
+                    "quantization": "bf16",
                     "supportsAudioInput": false,
-                    "supportsFunctionCalling": false,
-                    "supportsLogProbs": false,
-                    "supportsMultipleImages": false,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": true,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Hermes 3 405B is a frontier level, full parameter finetune of the Llama-3.1 405B foundation model, focused on aligning LLMs to the user, with powerful steering capabilities and control given to the end user.",
-                "name": "Hermes 3 Llama 3.1 405b",
-                "modelSource": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B",
+                "description": "Gemma 4 26B A4B is a Mixture-of-Experts model from Google DeepMind with 26B total parameters and only 4B active per token, offering fast inference at high quality. It handles text, image, and video input, supports 256K context, function calling, and reasoning with configurable thinking modes.",
+                "name": "Google Gemma 4 26B A4B Instruct",
+                "modelSource": "https://huggingface.co/google/gemma-4-26B-A4B-it",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -747,6 +1581,112 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
+            "created": 1775174400,
+            "id": "google-gemma-4-31b-it",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.12,
+                        "diem": 0.12
+                    },
+                    "cache_input": {
+                        "usd": 0.09,
+                        "diem": 0.09
+                    },
+                    "output": {
+                        "usd": 0.36,
+                        "diem": 0.36
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 8192,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "bf16",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": true,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemma 4 31B is a dense model from Google DeepMind with 31B parameters, delivering frontier-level reasoning performance. It handles text, image, and video input, supports 256K context, function calling, and configurable thinking modes.",
+                "name": "Google Gemma 4 31B Instruct",
+                "modelSource": "https://huggingface.co/google/gemma-4-31B-it",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1776038400,
+            "id": "gemma-4-uncensored",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.1625,
+                        "diem": 0.1625
+                    },
+                    "output": {
+                        "usd": 0.5,
+                        "diem": 0.5
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 8192,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "int4",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": true,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemma 4 Uncensored is an uncensored variant of Google Gemma 4 26B, a Mixture-of-Experts model with 26B total parameters and only 4B active per token. Fine-tuned for uncensored chat without content filtering, it supports 256K context, coding, and general-purpose conversation.",
+                "name": "Gemma 4 Uncensored",
+                "modelSource": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 198000,
             "created": 1762214400,
             "id": "google-gemma-3-27b-it",
             "model_spec": {
@@ -792,51 +1732,71 @@
             "type": "text"
         },
         {
-            "created": 1764547200,
-            "id": "grok-41-fast",
+            "context_length": 1000000,
+            "created": 1776470400,
+            "id": "grok-4-3",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.25,
-                        "diem": 0.25
+                        "usd": 1.42,
+                        "diem": 1.42
                     },
                     "cache_input": {
-                        "usd": 0.0625,
-                        "diem": 0.0625
+                        "usd": 0.23,
+                        "diem": 0.23
                     },
                     "output": {
-                        "usd": 0.625,
-                        "diem": 0.625
+                        "usd": 2.83,
+                        "diem": 2.83
+                    },
+                    "extended": {
+                        "context_token_threshold": 200000,
+                        "input": {
+                            "usd": 2.83,
+                            "diem": 2.83
+                        },
+                        "output": {
+                            "usd": 5.67,
+                            "diem": 5.67
+                        },
+                        "cache_input": {
+                            "usd": 0.45,
+                            "diem": 0.45
+                        }
                     }
                 },
-                "model_sets": [
-                    "venice_recommendations"
-                ],
                 "availableContextTokens": 1000000,
-                "maxCompletionTokens": 30000,
+                "maxCompletionTokens": 32000,
                 "capabilities": {
                     "optimizedForCode": false,
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
                     "supportsVideoInput": false,
                     "supportsVision": true,
                     "supportsWebSearch": true,
-                    "supportsXSearch": false
+                    "supportsXSearch": true
                 },
-                "description": "Grok 4.1 Fast is xAI's best agentic tool-calling model that shines in real-world use cases like customer support and image analysis.",
-                "name": "Grok 4.1 Fast",
-                "modelSource": "",
+                "description": "Grok 4.3 is xAI's most intelligent and fastest reasoning model with function calling, structured outputs, and a 1M-token context window. Suited for agentic workflows, instruction-following tasks, and applications requiring high factual accuracy.",
+                "name": "Grok 4.3",
+                "modelSource": "https://docs.x.ai/developers/models",
                 "offline": false,
-                "privacy": "anonymized",
+                "privacy": "private",
                 "traits": []
             },
             "object": "model",
@@ -844,36 +1804,110 @@
             "type": "text"
         },
         {
-            "created": 1773273600,
-            "id": "grok-4-20-beta",
+            "context_length": 500000,
+            "created": 1783382400,
+            "id": "grok-4-5",
             "model_spec": {
-                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 2.5,
-                        "diem": 2.5
+                        "usd": 2.27,
+                        "diem": 2.27
                     },
                     "cache_input": {
-                        "usd": 0.25,
-                        "diem": 0.25
+                        "usd": 0.34,
+                        "diem": 0.34
                     },
                     "output": {
-                        "usd": 7.5,
-                        "diem": 7.5
+                        "usd": 6.8,
+                        "diem": 6.8
                     },
                     "extended": {
                         "context_token_threshold": 200000,
                         "input": {
-                            "usd": 5,
-                            "diem": 5
+                            "usd": 4.53,
+                            "diem": 4.53
                         },
                         "output": {
-                            "usd": 15,
-                            "diem": 15
+                            "usd": 13.6,
+                            "diem": 13.6
                         },
                         "cache_input": {
-                            "usd": 0.25,
-                            "diem": 0.25
+                            "usd": 0.68,
+                            "diem": 0.68
+                        }
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 500000,
+                "maxCompletionTokens": 32000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": true
+                },
+                "description": "Grok 4.5 is xAI's intelligent coding model for agentic software engineering and workflow tasks, with function calling, structured outputs, and a 500K-token context window.",
+                "name": "Grok 4.5",
+                "modelSource": "https://docs.x.ai/developers/models",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 2000000,
+            "created": 1773273600,
+            "id": "grok-4-20",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.42,
+                        "diem": 1.42
+                    },
+                    "cache_input": {
+                        "usd": 0.23,
+                        "diem": 0.23
+                    },
+                    "output": {
+                        "usd": 2.83,
+                        "diem": 2.83
+                    },
+                    "extended": {
+                        "context_token_threshold": 200000,
+                        "input": {
+                            "usd": 2.83,
+                            "diem": 2.83
+                        },
+                        "output": {
+                            "usd": 5.67,
+                            "diem": 5.67
+                        },
+                        "cache_input": {
+                            "usd": 0.45,
+                            "diem": 0.45
                         }
                     }
                 },
@@ -884,11 +1918,11 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -897,11 +1931,11 @@
                     "supportsWebSearch": true,
                     "supportsXSearch": true
                 },
-                "description": "Grok 4.20 Beta is xAI's latest multimodal reasoning model with strong tool use, structured output support, and a 2M-token context window.",
-                "name": "Grok 4.20 Beta",
-                "modelSource": "",
+                "description": "Grok 4.20 is xAI's latest multimodal reasoning model with strong tool use, structured output support, and a 2M-token context window.",
+                "name": "Grok 4.20",
+                "modelSource": "https://docs.x.ai/developers/models",
                 "offline": false,
-                "privacy": "anonymized",
+                "privacy": "private",
                 "traits": []
             },
             "object": "model",
@@ -909,36 +1943,36 @@
             "type": "text"
         },
         {
+            "context_length": 2000000,
             "created": 1773273600,
-            "id": "grok-4-20-multi-agent-beta",
+            "id": "grok-4-20-multi-agent",
             "model_spec": {
-                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 2.5,
-                        "diem": 2.5
+                        "usd": 1.42,
+                        "diem": 1.42
                     },
                     "cache_input": {
-                        "usd": 0.25,
-                        "diem": 0.25
+                        "usd": 0.23,
+                        "diem": 0.23
                     },
                     "output": {
-                        "usd": 7.5,
-                        "diem": 7.5
+                        "usd": 2.83,
+                        "diem": 2.83
                     },
                     "extended": {
                         "context_token_threshold": 200000,
                         "input": {
-                            "usd": 5,
-                            "diem": 5
+                            "usd": 2.83,
+                            "diem": 2.83
                         },
                         "output": {
-                            "usd": 15,
-                            "diem": 15
+                            "usd": 5.67,
+                            "diem": 5.67
                         },
                         "cache_input": {
-                            "usd": 0.25,
-                            "diem": 0.25
+                            "usd": 0.45,
+                            "diem": 0.45
                         }
                     }
                 },
@@ -949,11 +1983,11 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": false,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -962,11 +1996,11 @@
                     "supportsWebSearch": true,
                     "supportsXSearch": true
                 },
-                "description": "Grok 4.20 Multi-Agent Beta is a variant of xAI Grok 4.20 designed for collaborative, agent-based workflows. Multiple agents operate in parallel to conduct deep research, coordinate tool use, and synthesize information across complex tasks.",
-                "name": "Grok 4.20 Multi-Agent Beta",
-                "modelSource": "",
+                "description": "Grok 4.20 Multi-Agent is a variant of xAI Grok 4.20 designed for collaborative, agent-based workflows. Multiple agents operate in parallel to conduct deep research, coordinate tool use, and synthesize information across complex tasks.",
+                "name": "Grok 4.20 Multi-Agent",
+                "modelSource": "https://x.ai/api",
                 "offline": false,
-                "privacy": "anonymized",
+                "privacy": "private",
                 "traits": []
             },
             "object": "model",
@@ -974,48 +2008,65 @@
             "type": "text"
         },
         {
-            "created": 1764633600,
-            "id": "gemini-3-pro-preview",
+            "context_length": 256000,
+            "created": 1779321600,
+            "id": "grok-build-0-1",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 2.5,
-                        "diem": 2.5
+                        "usd": 1,
+                        "diem": 1
                     },
                     "cache_input": {
-                        "usd": 0.625,
-                        "diem": 0.625
+                        "usd": 0.2,
+                        "diem": 0.2
                     },
                     "output": {
-                        "usd": 15,
-                        "diem": 15
+                        "usd": 2,
+                        "diem": 2
+                    },
+                    "extended": {
+                        "context_token_threshold": 200000,
+                        "input": {
+                            "usd": 2,
+                            "diem": 2
+                        },
+                        "output": {
+                            "usd": 4,
+                            "diem": 4
+                        },
+                        "cache_input": {
+                            "usd": 0.4,
+                            "diem": 0.4
+                        }
                     }
                 },
-                "availableContextTokens": 198000,
-                "maxCompletionTokens": 32768,
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
                 "capabilities": {
-                    "optimizedForCode": false,
+                    "optimizedForCode": true,
                     "quantization": "not-available",
-                    "supportsAudioInput": true,
+                    "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": true,
+                    "supportsVideoInput": false,
                     "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Gemini 3 Pro is Google flagship frontier model for high-precision multimodal reasoning with strong performance across text, image, and code.",
-                "name": "Gemini 3 Pro Preview",
-                "modelSource": "https://deepmind.google/models/gemini/pro/",
+                "description": "xAI's fast coding model trained specifically for agentic coding, currently in early access.",
+                "name": "Grok Build 0.1",
+                "modelSource": "https://docs.x.ai/developers/models/grok-build-0.1",
                 "offline": false,
-                "privacy": "anonymized",
+                "privacy": "private",
                 "traits": []
             },
             "object": "model",
@@ -1023,6 +2074,149 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
+            "created": 1768435200,
+            "id": "mistral-small-3-2-24b-instruct",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.09375,
+                        "diem": 0.09375
+                    },
+                    "output": {
+                        "usd": 0.25,
+                        "diem": 0.25
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Mistral Small 3.2 is a 24B parameter model optimized for efficiency and performance. Ideal for general-purpose tasks with balanced speed and capability.",
+                "name": "Mistral Small 3.2 24B Instruct",
+                "modelSource": "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1773619200,
+            "id": "mistral-small-2603",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.1875,
+                        "diem": 0.1875
+                    },
+                    "output": {
+                        "usd": 0.75,
+                        "diem": 0.75
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Mistral Small 4 unifies instruction following, reasoning, coding, and vision in a single 119B MoE model with 256K context and configurable reasoning effort.",
+                "name": "Mistral Small 4",
+                "modelSource": "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1758758400,
+            "id": "hermes-3-llama-3.1-405b",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.1,
+                        "diem": 1.1
+                    },
+                    "output": {
+                        "usd": 3,
+                        "diem": 3
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 16384,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Hermes 3 405B is a frontier level, full parameter finetune of the Llama-3.1 405B foundation model, focused on aligning LLMs to the user, with powerful steering capabilities and control given to the end user.",
+                "name": "Hermes 3 Llama 3.1 405b",
+                "modelSource": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
             "created": 1771459200,
             "id": "gemini-3-1-pro-preview",
             "model_spec": {
@@ -1070,11 +2264,17 @@
                     "quantization": "not-available",
                     "supportsAudioInput": true,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 20,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1095,6 +2295,67 @@
             "type": "text"
         },
         {
+            "context_length": 1000000,
+            "created": 1779408000,
+            "id": "gemini-3-5-flash",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.55,
+                        "diem": 1.55
+                    },
+                    "cache_input": {
+                        "usd": 0.155,
+                        "diem": 0.155
+                    },
+                    "cache_write": {
+                        "usd": 0.086,
+                        "diem": 0.086
+                    },
+                    "output": {
+                        "usd": 9.45,
+                        "diem": 9.45
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": true,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 20,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemini 3.5 Flash is a high speed, high value thinking model with 1M context, designed for agentic workflows, multi-turn chat, and coding assistance. It delivers near Pro level reasoning with substantially lower latency.",
+                "name": "Gemini 3.5 Flash",
+                "modelSource": "https://deepmind.google/models/gemini/flash/",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
             "created": 1766102400,
             "id": "gemini-3-flash-preview",
             "model_spec": {
@@ -1119,11 +2380,18 @@
                     "quantization": "not-available",
                     "supportsAudioInput": true,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1144,10 +2412,75 @@
             "type": "text"
         },
         {
-            "created": 1770249600,
-            "id": "claude-opus-4-6",
+            "context_length": 1000000,
+            "created": 1781049600,
+            "id": "claude-fable-5",
             "model_spec": {
-                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 12,
+                        "diem": 12
+                    },
+                    "cache_input": {
+                        "usd": 1.2,
+                        "diem": 1.2
+                    },
+                    "cache_write": {
+                        "usd": 15,
+                        "diem": 15
+                    },
+                    "output": {
+                        "usd": 60,
+                        "diem": 60
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Fable 5 is Anthropic's most capable widely released model, designed for demanding reasoning and long-horizon agentic work. It features a 1M token context window, 128K max output tokens, always-on adaptive thinking, and strong multimodal capabilities.",
+                "name": "Claude Fable 5",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1784764800,
+            "id": "claude-opus-5",
+            "model_spec": {
                 "pricing": {
                     "input": {
                         "usd": 6,
@@ -1180,7 +2513,280 @@
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Opus 5 is Anthropic's most capable model in the Opus family. It delivers major gains over Opus 4.8 in agentic coding, professional knowledge work, and long-horizon reasoning, with a 1M token context window, 128K max output tokens, adaptive thinking, and strong multimodal capabilities.",
+                "name": "Claude Opus 5",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1784764800,
+            "id": "claude-opus-5-fast",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 12,
+                        "diem": 12
+                    },
+                    "cache_input": {
+                        "usd": 1.2,
+                        "diem": 1.2
+                    },
+                    "cache_write": {
+                        "usd": 15,
+                        "diem": 15
+                    },
+                    "output": {
+                        "usd": 60,
+                        "diem": 60
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Opus 5 (Fast) is a speed-optimized variant of Anthropic's most capable Opus model, offering the same 1M token context window and strong performance across agentic coding, professional knowledge work, and long-horizon reasoning — with lower latency.",
+                "name": "Claude Opus 5 Fast",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1779926400,
+            "id": "claude-opus-4-8",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 6,
+                        "diem": 6
+                    },
+                    "cache_input": {
+                        "usd": 0.6,
+                        "diem": 0.6
+                    },
+                    "cache_write": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    },
+                    "output": {
+                        "usd": 30,
+                        "diem": 30
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Opus 4.8 is Anthropic's most capable generally available model in the Opus family. It supports long-horizon agentic work, complex multi-step coding, and memory-driven tasks where coherence over extended sessions matters. It features a 1M token context window, 128K max output tokens, adaptive thinking, and strong multimodal capabilities.",
+                "name": "Claude Opus 4.8",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1779926400,
+            "id": "claude-opus-4-8-fast",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 12,
+                        "diem": 12
+                    },
+                    "cache_input": {
+                        "usd": 1.2,
+                        "diem": 1.2
+                    },
+                    "cache_write": {
+                        "usd": 15,
+                        "diem": 15
+                    },
+                    "output": {
+                        "usd": 60,
+                        "diem": 60
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Opus 4.8 (Fast) is a speed-optimized variant of Anthropic's most capable generally available Opus model, offering the same 1M token context window and strong performance across long-horizon agentic work and complex coding — with lower latency.",
+                "name": "Claude Opus 4.8 Fast",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1776297600,
+            "id": "claude-opus-4-7",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 6,
+                        "diem": 6
+                    },
+                    "cache_input": {
+                        "usd": 0.6,
+                        "diem": 0.6
+                    },
+                    "cache_write": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    },
+                    "output": {
+                        "usd": 30,
+                        "diem": 30
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Opus 4.7 is Anthropic's most capable generally available model for complex reasoning and agentic coding. It features a 1M token context window, 128K max output tokens, adaptive thinking, and strong multimodal capabilities.",
+                "name": "Claude Opus 4.7",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1770249600,
+            "id": "claude-opus-4-6",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 6,
+                        "diem": 6
+                    },
+                    "cache_input": {
+                        "usd": 0.6,
+                        "diem": 0.6
+                    },
+                    "cache_write": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    },
+                    "output": {
+                        "usd": 30,
+                        "diem": 30
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1201,6 +2807,7 @@
             "type": "text"
         },
         {
+            "context_length": 198000,
             "created": 1764979200,
             "id": "claude-opus-4-5",
             "model_spec": {
@@ -1233,7 +2840,7 @@
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1254,6 +2861,62 @@
             "type": "text"
         },
         {
+            "context_length": 1000000,
+            "created": 1782691200,
+            "id": "claude-sonnet-5",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 3,
+                        "diem": 3
+                    },
+                    "cache_input": {
+                        "usd": 0.3,
+                        "diem": 0.3
+                    },
+                    "cache_write": {
+                        "usd": 3.75,
+                        "diem": 3.75
+                    },
+                    "output": {
+                        "usd": 15,
+                        "diem": 15
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 64000,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Claude Sonnet 5 is Anthropic's latest Sonnet model, substantially improving on Sonnet 4.6 in coding and agentic work and reaching near-Opus quality on many tasks. It features a 1M token context window, adaptive thinking, and strong document and vision understanding.",
+                "name": "Claude Sonnet 5",
+                "modelSource": "",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
             "created": 1771286400,
             "id": "claude-sonnet-4-6",
             "model_spec": {
@@ -1276,6 +2939,9 @@
                         "diem": 18
                     }
                 },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
                 "availableContextTokens": 1000000,
                 "maxCompletionTokens": 64000,
                 "capabilities": {
@@ -1287,7 +2953,7 @@
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1308,6 +2974,7 @@
             "type": "text"
         },
         {
+            "context_length": 198000,
             "created": 1736899200,
             "id": "claude-sonnet-4-5",
             "model_spec": {
@@ -1340,7 +3007,7 @@
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
+                    "supportsReasoningEffort": false,
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1361,6 +3028,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1762387200,
             "id": "openai-gpt-oss-120b",
             "model_spec": {
@@ -1383,8 +3051,15 @@
                     "supportsFunctionCalling": true,
                     "supportsLogProbs": false,
                     "supportsMultipleImages": false,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": false,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1405,8 +3080,9 @@
             "type": "text"
         },
         {
-            "created": 1765324800,
-            "id": "kimi-k2-thinking",
+            "context_length": 256000,
+            "created": 1776643200,
+            "id": "kimi-k2-6",
             "model_spec": {
                 "pricing": {
                     "input": {
@@ -1414,12 +3090,12 @@
                         "diem": 0.75
                     },
                     "cache_input": {
-                        "usd": 0.375,
-                        "diem": 0.375
+                        "usd": 0.16,
+                        "diem": 0.16
                     },
                     "output": {
-                        "usd": 3.2,
-                        "diem": 3.2
+                        "usd": 3.5,
+                        "diem": 3.5
                     }
                 },
                 "availableContextTokens": 256000,
@@ -1429,21 +3105,29 @@
                     "quantization": "int4",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
                     "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Kimi K2 Thinking is Moonshot AIs most advanced open reasoning model to date, extending the K2 series into agentic, long-horizon reasoning. Built on the trillion-parameter Mixture-of-Experts (MoE) architecture introduced in Kimi K2, it activates 32 billion parameters per forward pass and supports 256 k-token context windows.",
-                "name": "Kimi K2 Thinking",
-                "modelSource": "https://huggingface.co/moonshotai/Kimi-K2-Thinking",
+                "description": "Kimi K2.6 is an open-source, native multimodal agentic model from Moonshot AI with 1T total parameters and 32B active parameters. It excels at long-horizon coding, coding-driven design, agent swarm orchestration, and proactive autonomous execution with 256K context windows.",
+                "name": "Kimi K2.6",
+                "modelSource": "https://huggingface.co/moonshotai/Kimi-K2.6",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -1453,6 +3137,64 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
+            "created": 1781308800,
+            "id": "kimi-k2-7-code",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.75,
+                        "diem": 0.75
+                    },
+                    "cache_input": {
+                        "usd": 0.16,
+                        "diem": 0.16
+                    },
+                    "output": {
+                        "usd": 3.5,
+                        "diem": 3.5
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "int4",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Kimi K2.7 Code is Moonshot AI's coding-focused agentic model built on Kimi K2.6, with 1T total parameters and 32B active parameters. It always operates in thinking mode, supports text and image input, and targets long-horizon software engineering, agentic task decomposition, and multi-turn coding workflows with 256K context.",
+                "name": "Kimi K2.7 Code",
+                "modelSource": "https://huggingface.co/moonshotai/Kimi-K2.7-Code",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
             "created": 1769548800,
             "id": "kimi-k2-5",
             "model_spec": {
@@ -1462,17 +3204,14 @@
                         "diem": 0.56
                     },
                     "cache_input": {
-                        "usd": 0.11,
-                        "diem": 0.11
+                        "usd": 0.22,
+                        "diem": 0.22
                     },
                     "output": {
                         "usd": 3.5,
                         "diem": 3.5
                     }
                 },
-                "model_sets": [
-                    "venice_recommendations"
-                ],
                 "availableContextTokens": 256000,
                 "maxCompletionTokens": 65536,
                 "capabilities": {
@@ -1480,11 +3219,18 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
+                    "supportsLogProbs": true,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1495,7 +3241,7 @@
                 },
                 "description": "Kimi K2.5 is Moonshot AIs most advanced open reasoning model, featuring trillion-parameter Mixture-of-Experts architecture with 32B active parameters and 256K context windows.",
                 "name": "Kimi K2.5",
-                "modelSource": "",
+                "modelSource": "https://github.com/MoonshotAI/Kimi-K2.5",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -1505,38 +3251,369 @@
             "type": "text"
         },
         {
-            "created": 1764806400,
-            "id": "deepseek-v3.2",
+            "context_length": 1000000,
+            "created": 1784160000,
+            "id": "kimi-k3",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.4,
-                        "diem": 0.4
+                        "usd": 3.75,
+                        "diem": 3.75
                     },
                     "cache_input": {
-                        "usd": 0.2,
-                        "diem": 0.2
+                        "usd": 0.375,
+                        "diem": 0.375
                     },
                     "output": {
-                        "usd": 1,
-                        "diem": 1
+                        "usd": 18.75,
+                        "diem": 18.75
                     }
                 },
                 "model_sets": [
                     "venice_recommendations"
                 ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 131072,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Kimi K3 is an ultra-large-scale, open-weight multimodal reasoning model from Moonshot AI. It is suited for complex coding, knowledge work, and long-horizon agentic workflows, and is particularly strong at navigating large repositories, using tools, debugging, and iterating against images, logs, tests, and runtime feedback.",
+                "name": "Kimi K3",
+                "modelSource": "https://huggingface.co/moonshotai/Kimi-K3",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 524288,
+            "created": 1784160000,
+            "id": "inkling",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.25,
+                        "diem": 1.25
+                    },
+                    "cache_input": {
+                        "usd": 0.2125,
+                        "diem": 0.2125
+                    },
+                    "output": {
+                        "usd": 5.0625,
+                        "diem": 5.0625
+                    }
+                },
+                "availableContextTokens": 524288,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": true,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Inkling is a general-purpose multimodal model from Thinking Machines Lab that accepts text, image, and audio inputs and generates text. It is a 66-layer sparse MoE (975B total / 41B active) with hybrid local/global attention, 512K context, and variable thinking effort — suited for chat, coding, tool use, and agentic workflows. Video input is not supported on Venice.",
+                "name": "Inkling",
+                "modelSource": "https://huggingface.co/thinkingmachines/Inkling-NVFP4",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1781136000,
+            "id": "xiaomi-mimo-v2-5",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.14,
+                        "diem": 0.14
+                    },
+                    "cache_input": {
+                        "usd": 0.05,
+                        "diem": 0.05
+                    },
+                    "output": {
+                        "usd": 0.28,
+                        "diem": 0.28
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": true,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "MiMo-V2.5 is Xiaomi's native omnimodal model with strong agentic capabilities, supporting text, image, video, and audio understanding in a unified architecture. Built on a sparse Mixture-of-Experts backbone with 310B total and 15B active parameters, it delivers long-context reasoning up to 1M tokens, function calling, and multimodal perception.",
+                "name": "MiMo-V2.5",
+                "modelSource": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1776988800,
+            "id": "deepseek-v4-pro",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 1.65,
+                        "diem": 1.65
+                    },
+                    "cache_input": {
+                        "usd": 0.33,
+                        "diem": 0.33
+                    },
+                    "output": {
+                        "usd": 3.301,
+                        "diem": 3.301
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "DeepSeek V4 Pro is a 1.6T-parameter Mixture-of-Experts model with 49B active parameters and a 1M-token context window. Built for advanced reasoning, coding, and long-horizon agentic workflows with a hybrid attention system for efficient long-context processing.",
+                "name": "DeepSeek V4 Pro",
+                "modelSource": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1776988800,
+            "id": "deepseek-v4-flash",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.138,
+                        "diem": 0.138
+                    },
+                    "cache_input": {
+                        "usd": 0.028,
+                        "diem": 0.028
+                    },
+                    "output": {
+                        "usd": 0.275,
+                        "diem": 0.275
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "DeepSeek V4 Flash is an efficiency-optimized 284B-parameter Mixture-of-Experts model with 13B active parameters and a 1M-token context window. Tuned for fast inference and high-throughput workloads while maintaining strong reasoning and coding performance.",
+                "name": "DeepSeek V4 Flash 0423",
+                "modelSource": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1785456000,
+            "id": "deepseek-v4-flash-0731",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.175,
+                        "diem": 0.175
+                    },
+                    "cache_input": {
+                        "usd": 0.035,
+                        "diem": 0.035
+                    },
+                    "output": {
+                        "usd": 0.35,
+                        "diem": 0.35
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "high",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "DeepSeek V4 Flash is an efficiency-optimized 284B-parameter Mixture-of-Experts model with 13B active parameters and a 1M-token context window. Tuned for fast inference and high-throughput workloads while maintaining strong reasoning and coding performance.",
+                "name": "DeepSeek V4 Flash 0731",
+                "modelSource": "https://deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731/api",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 160000,
+            "created": 1764806400,
+            "id": "deepseek-v3.2",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.33,
+                        "diem": 0.33
+                    },
+                    "cache_input": {
+                        "usd": 0.16,
+                        "diem": 0.16
+                    },
+                    "output": {
+                        "usd": 0.48,
+                        "diem": 0.48
+                    }
+                },
                 "availableContextTokens": 160000,
                 "maxCompletionTokens": 32768,
                 "capabilities": {
                     "optimizedForCode": false,
                     "quantization": "not-available",
                     "supportsAudioInput": false,
-                    "supportsFunctionCalling": false,
+                    "supportsFunctionCalling": true,
                     "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": false,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
                     "supportsVideoInput": false,
@@ -1556,6 +3633,220 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
+            "created": 1782604800,
+            "id": "seed-2-1-turbo",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "cache_input": {
+                        "usd": 0.125,
+                        "diem": 0.125
+                    },
+                    "output": {
+                        "usd": 3.125,
+                        "diem": 3.125
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 65536,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "maxVideos": 4,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Seed 2.1 Turbo (Dola-Seed-2.1) is ByteDance’s next-generation multimodal model for the coding and agent era, with engineering-grade code delivery, long-horizon agent execution, and upgraded GUI and video understanding. Supports text, image, and video inputs with a 256K context window.",
+                "name": "Seed 2.1 Turbo",
+                "modelSource": "https://console.byteplus.com/ark/region:ark+ap-southeast-1/model/detail?Id=dola-seed-2-1-turbo",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1785715200,
+            "id": "kimi-k3-fast-api",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 4.5,
+                        "diem": 4.5
+                    },
+                    "cache_input": {
+                        "usd": 0.45,
+                        "diem": 0.45
+                    },
+                    "output": {
+                        "usd": 22.5,
+                        "diem": 22.5
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 131072,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Kimi K3 is an ultra-large-scale, open-weight multimodal reasoning model from Moonshot AI. It is suited for complex coding, knowledge work, and long-horizon agentic workflows, and is particularly strong at navigating large repositories, using tools, debugging, and iterating against images, logs, tests, and runtime feedback.",
+                "name": "Kimi K3 Fast",
+                "modelSource": "https://huggingface.co/moonshotai/Kimi-K3",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1783468800,
+            "id": "aion-labs-aion-3-0",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 3.75,
+                        "diem": 3.75
+                    },
+                    "cache_input": {
+                        "usd": 0.9375,
+                        "diem": 0.9375
+                    },
+                    "output": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Aion 3.0 is a multi-model roleplaying and storytelling system from AionLabs, built on the GLM family of models. Multiple specialized models collaborate on each response to produce stronger narrative structure and more compelling tension and conflict. It handles mature and darker themes with nuance and supports tool calling for richer interactive fiction.",
+                "name": "Aion 3.0",
+                "modelSource": "https://openrouter.ai/aion-labs/aion-3.0",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1783468800,
+            "id": "aion-labs-aion-3-0-mini",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.875,
+                        "diem": 0.875
+                    },
+                    "cache_input": {
+                        "usd": 0.225,
+                        "diem": 0.225
+                    },
+                    "output": {
+                        "usd": 1.75,
+                        "diem": 1.75
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Aion 3.0 Mini is a multi-model roleplaying and storytelling system from AionLabs, built on the DeepSeek family of models. Multiple specialized models collaborate on each response to produce stronger narrative structure and more compelling tension and conflict at lower cost. It handles mature and darker themes with nuance and supports tool calling for richer interactive fiction.",
+                "name": "Aion 3.0 Mini",
+                "modelSource": "https://openrouter.ai/aion-labs/aion-3.0-mini",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
             "created": 1727966436,
             "id": "llama-3.2-3b",
             "model_spec": {
@@ -1576,7 +3867,7 @@
                     "quantization": "fp16",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": false,
                     "supportsReasoningEffort": false,
@@ -1599,6 +3890,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1743897600,
             "id": "llama-3.3-70b",
             "model_spec": {
@@ -1642,6 +3934,7 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
             "created": 1765584000,
             "id": "openai-gpt-52",
             "model_spec": {
@@ -1659,9 +3952,6 @@
                         "diem": 17.5
                     }
                 },
-                "model_sets": [
-                    "venice_recommendations"
-                ],
                 "availableContextTokens": 256000,
                 "maxCompletionTokens": 65536,
                 "capabilities": {
@@ -1669,10 +3959,18 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1683,7 +3981,7 @@
                 },
                 "description": "GPT-5.2 is the latest frontier-grade model in the GPT-5 series, offering stronger agentic and long context performance compared to GPT-5.1. It uses adaptive reasoning to allocate computation dynamically, responding quickly to simple queries while spending more depth on complex tasks.",
                 "name": "GPT-5.2",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.2",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1693,6 +3991,7 @@
             "type": "text"
         },
         {
+            "context_length": 256000,
             "created": 1736899200,
             "id": "openai-gpt-52-codex",
             "model_spec": {
@@ -1717,11 +4016,19 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1732,7 +4039,7 @@
                 },
                 "description": "GPT-5.2 Codex is OpenAI specialized coding model built on GPT-5.2, optimized for advanced software development, code generation, and technical problem-solving.",
                 "name": "GPT-5.2 Codex",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.2-codex",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1742,6 +4049,7 @@
             "type": "text"
         },
         {
+            "context_length": 400000,
             "created": 1771891200,
             "id": "openai-gpt-53-codex",
             "model_spec": {
@@ -1767,11 +4075,19 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1782,7 +4098,7 @@
                 },
                 "description": "GPT-5.3 Codex is OpenAI specialized coding model built on GPT-5.3, optimized for advanced software development, code generation, and technical problem-solving.",
                 "name": "GPT-5.3 Codex",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.3-codex",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1792,6 +4108,7 @@
             "type": "text"
         },
         {
+            "context_length": 1000000,
             "created": 1772668800,
             "id": "openai-gpt-54",
             "model_spec": {
@@ -1817,11 +4134,19 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1832,7 +4157,7 @@
                 },
                 "description": "GPT-5.4 is the latest frontier model in the GPT-5 series with a 1M+ context window, offering improved agentic and long context performance. It uses adaptive reasoning to dynamically allocate computation across tasks.",
                 "name": "GPT-5.4",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.4",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1842,6 +4167,7 @@
             "type": "text"
         },
         {
+            "context_length": 1000000,
             "created": 1772668800,
             "id": "openai-gpt-54-pro",
             "model_spec": {
@@ -1874,11 +4200,19 @@
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": true,
                     "maxImages": 10,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "medium",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -1889,7 +4223,7 @@
                 },
                 "description": "GPT-5.4 Pro is OpenAI's most advanced model, building on GPT-5.4's unified architecture with enhanced reasoning for complex, high-stakes tasks. It provides a 1M+ token context window (922K input, 128K output) and supports text and image inputs.",
                 "name": "GPT-5.4 Pro",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.4-pro",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1899,6 +4233,580 @@
             "type": "text"
         },
         {
+            "context_length": 400000,
+            "created": 1774569600,
+            "id": "openai-gpt-54-mini",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.9375,
+                        "diem": 0.9375
+                    },
+                    "cache_input": {
+                        "usd": 0.09375,
+                        "diem": 0.09375
+                    },
+                    "output": {
+                        "usd": 5.625,
+                        "diem": 5.625
+                    }
+                },
+                "availableContextTokens": 400000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.4 Mini brings the core capabilities of GPT-5.4 to a faster, more efficient model optimized for high-throughput workloads. It supports text and image inputs with strong performance across reasoning, coding, and tool use.",
+                "name": "GPT-5.4 Mini",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1776902400,
+            "id": "openai-gpt-55",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 6.25,
+                        "diem": 6.25
+                    },
+                    "cache_input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "output": {
+                        "usd": 37.5,
+                        "diem": 37.5
+                    },
+                    "extended": {
+                        "context_token_threshold": 272000,
+                        "input": {
+                            "usd": 12.5,
+                            "diem": 12.5
+                        },
+                        "output": {
+                            "usd": 56.25,
+                            "diem": 56.25
+                        },
+                        "cache_input": {
+                            "usd": 1.25,
+                            "diem": 1.25
+                        }
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 131072,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.5 is the latest frontier model in the GPT-5 series with a 1M+ context window, offering improved agentic and long context performance. It uses adaptive reasoning to dynamically allocate computation across tasks.",
+                "name": "GPT-5.5",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.5",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1776988800,
+            "id": "openai-gpt-55-pro",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 37.5,
+                        "diem": 37.5
+                    },
+                    "output": {
+                        "usd": 225,
+                        "diem": 225
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "medium",
+                        "high",
+                        "xhigh"
+                    ],
+                    "defaultReasoningEffort": "medium",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.5 Pro is OpenAI's most advanced model, building on GPT-5.5's unified architecture with enhanced reasoning for complex, high-stakes tasks. It provides a 1M+ token context window (922K input, 128K output) and supports text and image inputs.",
+                "name": "GPT-5.5 Pro",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-5.5-pro",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-luna",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.25,
+                        "diem": 1.25
+                    },
+                    "cache_input": {
+                        "usd": 0.125,
+                        "diem": 0.125
+                    },
+                    "cache_write": {
+                        "usd": 1.5625,
+                        "diem": 1.5625
+                    },
+                    "output": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Luna is a fast, cost-efficient model in OpenAI's GPT-5.6 series. It is suited for high-volume, latency-sensitive tasks such as chat, classification, and lightweight agentic workflows, providing capable reasoning for its price tier.",
+                "name": "GPT-5.6 Luna",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-luna",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-luna-pro",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.25,
+                        "diem": 1.25
+                    },
+                    "cache_input": {
+                        "usd": 0.125,
+                        "diem": 0.125
+                    },
+                    "cache_write": {
+                        "usd": 1.5625,
+                        "diem": 1.5625
+                    },
+                    "output": {
+                        "usd": 7.5,
+                        "diem": 7.5
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "medium",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Luna Pro is the same underlying model as GPT-5.6 Luna, served with reasoning.mode set to pro for higher-quality responses on complex tasks.",
+                "name": "GPT-5.6 Luna Pro",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-luna-pro",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-terra",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 3.125,
+                        "diem": 3.125
+                    },
+                    "cache_input": {
+                        "usd": 0.3125,
+                        "diem": 0.3125
+                    },
+                    "cache_write": {
+                        "usd": 3.90625,
+                        "diem": 3.90625
+                    },
+                    "output": {
+                        "usd": 18.75,
+                        "diem": 18.75
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Terra is a balanced model in OpenAI's GPT-5.6 series, positioned between the flagship Sol tier and the cost-efficient Luna tier. It is suited for everyday coding, reasoning, and agentic tasks where capability and cost need to be balanced.",
+                "name": "GPT-5.6 Terra",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-terra",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-terra-pro",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 3.125,
+                        "diem": 3.125
+                    },
+                    "cache_input": {
+                        "usd": 0.3125,
+                        "diem": 0.3125
+                    },
+                    "cache_write": {
+                        "usd": 3.90625,
+                        "diem": 3.90625
+                    },
+                    "output": {
+                        "usd": 18.75,
+                        "diem": 18.75
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "medium",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Terra Pro is the same underlying model as GPT-5.6 Terra, served with reasoning.mode set to pro for higher-quality responses on complex tasks.",
+                "name": "GPT-5.6 Terra Pro",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-terra-pro",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-sol",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 6.25,
+                        "diem": 6.25
+                    },
+                    "cache_input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "cache_write": {
+                        "usd": 7.8125,
+                        "diem": 7.8125
+                    },
+                    "output": {
+                        "usd": 37.5,
+                        "diem": 37.5
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "high",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Sol is the flagship model in OpenAI's GPT-5.6 series. It is suited for complex reasoning, coding, and agentic workflows, and is particularly strong at command-line and multi-step coding tasks and long-horizon problem solving.",
+                "name": "GPT-5.6 Sol",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-sol",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783555200,
+            "id": "openai-gpt-56-sol-pro",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 6.25,
+                        "diem": 6.25
+                    },
+                    "cache_input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "cache_write": {
+                        "usd": 7.8125,
+                        "diem": 7.8125
+                    },
+                    "output": {
+                        "usd": 37.5,
+                        "diem": 37.5
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 128000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max"
+                    ],
+                    "defaultReasoningEffort": "medium",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT-5.6 Sol Pro is the same underlying model as GPT-5.6 Sol, served with reasoning.mode set to pro for higher-quality responses on complex tasks.",
+                "name": "GPT-5.6 Sol Pro",
+                "modelSource": "https://openrouter.ai/openai/gpt-5.6-sol-pro",
+                "offline": false,
+                "privacy": "anonymized",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
             "created": 1772236800,
             "id": "openai-gpt-4o-2024-11-20",
             "model_spec": {
@@ -1934,7 +4842,7 @@
                 },
                 "description": "OpenAI's multimodal flagship model with vision capabilities, strong reasoning, and broad knowledge. Popular for its balanced performance across tasks. Version: 2024-11-20.",
                 "name": "GPT-4o",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-4o",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1944,6 +4852,7 @@
             "type": "text"
         },
         {
+            "context_length": 128000,
             "created": 1772236800,
             "id": "openai-gpt-4o-mini-2024-07-18",
             "model_spec": {
@@ -1983,7 +4892,7 @@
                 },
                 "description": "OpenAI's cost-efficient small model that delivers GPT-4 level intelligence at a fraction of the cost. Ideal for high-volume applications requiring strong reasoning. Version: 2024-07-18.",
                 "name": "GPT-4o Mini",
-                "modelSource": "",
+                "modelSource": "https://developers.openai.com/api/docs/models/gpt-4o-mini",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -1993,45 +4902,48 @@
             "type": "text"
         },
         {
-            "created": 1764547200,
-            "id": "minimax-m21",
+            "context_length": 524288,
+            "created": 1781222400,
+            "id": "minimax-m3-preview",
             "model_spec": {
+                "betaModel": true,
                 "pricing": {
                     "input": {
-                        "usd": 0.35,
-                        "diem": 0.35
+                        "usd": 0.3,
+                        "diem": 0.3
                     },
                     "cache_input": {
-                        "usd": 0.04,
-                        "diem": 0.04
+                        "usd": 0.06,
+                        "diem": 0.06
                     },
                     "output": {
-                        "usd": 1.5,
-                        "diem": 1.5
+                        "usd": 1.2,
+                        "diem": 1.2
                     }
                 },
-                "availableContextTokens": 198000,
-                "maxCompletionTokens": 32768,
+                "availableContextTokens": 524288,
+                "maxCompletionTokens": 65536,
                 "capabilities": {
                     "optimizedForCode": true,
-                    "quantization": "not-available",
+                    "quantization": "fp8",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": true,
+                    "maxImages": 10,
                     "supportsReasoning": true,
-                    "supportsReasoningEffort": true,
-                    "supportsResponseSchema": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
+                    "supportsVideoInput": true,
+                    "supportsVision": true,
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "MiniMax-M2.1 is a lightweight, state-of-the-art large language model optimized for coding, agentic workflows, and modern application development.",
-                "name": "MiniMax M2.1",
-                "modelSource": "https://huggingface.co/MiniMaxAI/MiniMax-M2.1",
+                "description": "MiniMax-M3 preview is a 1.4T-parameter frontier model from MiniMax for coding, agentic workflows, and complex reasoning, served at fp8 with a 512K context window.",
+                "name": "MiniMax M3 Preview",
+                "modelSource": "https://huggingface.co/MiniMaxAI/MiniMax-M3",
                 "offline": false,
                 "privacy": "private",
                 "traits": []
@@ -2041,21 +4953,22 @@
             "type": "text"
         },
         {
+            "context_length": 198000,
             "created": 1770854400,
             "id": "minimax-m25",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.34,
-                        "diem": 0.34
+                        "usd": 0.27,
+                        "diem": 0.27
                     },
                     "cache_input": {
-                        "usd": 0.04,
-                        "diem": 0.04
+                        "usd": 0.03,
+                        "diem": 0.03
                     },
                     "output": {
-                        "usd": 1.19,
-                        "diem": 1.19
+                        "usd": 0.95,
+                        "diem": 0.95
                     }
                 },
                 "availableContextTokens": 198000,
@@ -2069,6 +4982,12 @@
                     "supportsMultipleImages": false,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
                     "supportsResponseSchema": false,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -2088,34 +5007,98 @@
             "type": "text"
         },
         {
-            "created": 1764547200,
-            "id": "grok-code-fast-1",
+            "context_length": 198000,
+            "created": 1773792000,
+            "id": "minimax-m27",
             "model_spec": {
                 "pricing": {
                     "input": {
-                        "usd": 0.25,
-                        "diem": 0.25
+                        "usd": 0.375,
+                        "diem": 0.375
                     },
                     "cache_input": {
-                        "usd": 0.03,
-                        "diem": 0.03
+                        "usd": 0.06875,
+                        "diem": 0.06875
                     },
                     "output": {
-                        "usd": 1.87,
-                        "diem": 1.87
+                        "usd": 1.5,
+                        "diem": 1.5
                     }
                 },
-                "availableContextTokens": 256000,
-                "maxCompletionTokens": 10000,
+                "availableContextTokens": 198000,
+                "maxCompletionTokens": 32768,
                 "capabilities": {
                     "optimizedForCode": true,
                     "quantization": "not-available",
                     "supportsAudioInput": false,
                     "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
+                    "supportsLogProbs": false,
                     "supportsMultipleImages": false,
                     "supportsReasoning": true,
                     "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "MiniMax-M2.7 is a next-generation large language model designed for autonomous, real-world productivity with advanced agentic capabilities through multi-agent collaboration.",
+                "name": "MiniMax M2.7",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1771545600,
+            "id": "mercury-2",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.3125,
+                        "diem": 0.3125
+                    },
+                    "cache_input": {
+                        "usd": 0.03125,
+                        "diem": 0.03125
+                    },
+                    "output": {
+                        "usd": 0.9375,
+                        "diem": 0.9375
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 50000,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "high",
                     "supportsResponseSchema": true,
                     "supportsTeeAttestation": false,
                     "supportsE2EE": false,
@@ -2124,9 +5107,9 @@
                     "supportsWebSearch": true,
                     "supportsXSearch": false
                 },
-                "description": "Grok Code Fast 1 is a speedy and economical reasoning model that excels at agentic coding",
-                "name": "Grok Code Fast 1",
-                "modelSource": "",
+                "description": "Mercury 2 is a diffusion-based reasoning LLM from Inception, delivering over 1,000 tokens per second — 5x faster than leading speed-optimized models — with strong reasoning, tool use, and structured output capabilities.",
+                "name": "Mercury 2",
+                "modelSource": "https://www.inceptionlabs.ai/models",
                 "offline": false,
                 "privacy": "anonymized",
                 "traits": []
@@ -2136,163 +5119,7 @@
             "type": "text"
         },
         {
-            "created": 1771977600,
-            "id": "qwen3-5-35b-a3b",
-            "model_spec": {
-                "betaModel": true,
-                "pricing": {
-                    "input": {
-                        "usd": 0.3125,
-                        "diem": 0.3125
-                    },
-                    "cache_input": {
-                        "usd": 0.15625,
-                        "diem": 0.15625
-                    },
-                    "output": {
-                        "usd": 1.25,
-                        "diem": 1.25
-                    }
-                },
-                "availableContextTokens": 256000,
-                "maxCompletionTokens": 65536,
-                "capabilities": {
-                    "optimizedForCode": true,
-                    "quantization": "not-available",
-                    "supportsAudioInput": false,
-                    "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": true,
-                    "maxImages": 5,
-                    "supportsReasoning": true,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
-                    "supportsTeeAttestation": false,
-                    "supportsE2EE": false,
-                    "supportsVideoInput": true,
-                    "supportsVision": true,
-                    "supportsWebSearch": true,
-                    "supportsXSearch": false
-                },
-                "constraints": {
-                    "temperature": {
-                        "default": 1
-                    },
-                    "top_p": {
-                        "default": 0.95
-                    },
-                    "repetition_penalty": {
-                        "default": 1
-                    }
-                },
-                "description": "Qwen 3.5 35B A3B is a highly efficient MoE model with 35B total parameters and only 3B active parameters. It surpasses the larger Qwen3-235B-A22B while being 6.7x smaller, excelling at reasoning, coding, and general knowledge tasks.",
-                "name": "Qwen 3.5 35B A3B",
-                "modelSource": "",
-                "offline": false,
-                "privacy": "private",
-                "traits": []
-            },
-            "object": "model",
-            "owned_by": "venice.ai",
-            "type": "text"
-        },
-        {
-            "created": 1768521600,
-            "id": "qwen3-vl-235b-a22b",
-            "model_spec": {
-                "pricing": {
-                    "input": {
-                        "usd": 0.25,
-                        "diem": 0.25
-                    },
-                    "output": {
-                        "usd": 1.5,
-                        "diem": 1.5
-                    }
-                },
-                "availableContextTokens": 256000,
-                "maxCompletionTokens": 16384,
-                "capabilities": {
-                    "optimizedForCode": false,
-                    "quantization": "fp8",
-                    "supportsAudioInput": false,
-                    "supportsFunctionCalling": true,
-                    "supportsLogProbs": false,
-                    "supportsMultipleImages": true,
-                    "maxImages": 10,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
-                    "supportsTeeAttestation": false,
-                    "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": true,
-                    "supportsWebSearch": true,
-                    "supportsXSearch": false
-                },
-                "description": "Qwen3-VL 235B vision-language model with MoE architecture. The most powerful VL model in the Qwen series with superior visual perception, OCR, and multimodal reasoning.",
-                "name": "Qwen3 VL 235B",
-                "modelSource": "https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct",
-                "offline": false,
-                "privacy": "private",
-                "traits": [
-                    "default_vision"
-                ]
-            },
-            "object": "model",
-            "owned_by": "venice.ai",
-            "type": "text"
-        },
-        {
-            "created": 1769472000,
-            "id": "qwen3-coder-480b-a35b-instruct-turbo",
-            "model_spec": {
-                "betaModel": true,
-                "pricing": {
-                    "input": {
-                        "usd": 0.35,
-                        "diem": 0.35
-                    },
-                    "cache_input": {
-                        "usd": 0.04,
-                        "diem": 0.04
-                    },
-                    "output": {
-                        "usd": 1.5,
-                        "diem": 1.5
-                    }
-                },
-                "availableContextTokens": 256000,
-                "maxCompletionTokens": 65536,
-                "capabilities": {
-                    "optimizedForCode": true,
-                    "quantization": "fp8",
-                    "supportsAudioInput": false,
-                    "supportsFunctionCalling": true,
-                    "supportsLogProbs": true,
-                    "supportsMultipleImages": false,
-                    "supportsReasoning": false,
-                    "supportsReasoningEffort": false,
-                    "supportsResponseSchema": true,
-                    "supportsTeeAttestation": false,
-                    "supportsE2EE": false,
-                    "supportsVideoInput": false,
-                    "supportsVision": false,
-                    "supportsWebSearch": true,
-                    "supportsXSearch": false
-                },
-                "description": "Turbo variant of Qwen3 Coder 480B, optimized for faster inference on code tasks.",
-                "name": "Qwen 3 Coder 480B Turbo",
-                "modelSource": "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo",
-                "offline": false,
-                "privacy": "private",
-                "traits": []
-            },
-            "object": "model",
-            "owned_by": "venice.ai",
-            "type": "text"
-        },
-        {
+            "context_length": 128000,
             "created": 1769472000,
             "id": "nvidia-nemotron-3-nano-30b-a3b",
             "model_spec": {
@@ -2329,6 +5156,700 @@
                 "description": "NVIDIA Nemotron 3 Nano 30B is a compact and efficient language model from NVIDIA, optimized for fast inference while maintaining strong performance across diverse tasks.",
                 "name": "NVIDIA Nemotron 3 Nano 30B",
                 "modelSource": "https://huggingface.co/nvidia/Nemotron-3-Nano-30B-A3B",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1780531200,
+            "id": "nvidia-nemotron-3-ultra-550b-a55b",
+            "model_spec": {
+                "pricing": {
+                    "input": {
+                        "usd": 0.625,
+                        "diem": 0.625
+                    },
+                    "cache_input": {
+                        "usd": 0.1875,
+                        "diem": 0.1875
+                    },
+                    "output": {
+                        "usd": 3.125,
+                        "diem": 3.125
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": true,
+                    "supportsTeeAttestation": false,
+                    "supportsE2EE": false,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "NVIDIA Nemotron 3 Ultra is built for frontier reasoning, orchestration, coding agents, deep research, and complex enterprise workflows. It delivers up to 5x faster inference and up to 30% lower cost for agentic workloads while supporting up to 1M token context.",
+                "name": "NVIDIA Nemotron 3 Ultra",
+                "modelSource": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 40000,
+            "created": 1773792000,
+            "id": "e2ee-gemma-3-27b-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.14,
+                        "diem": 0.14
+                    },
+                    "output": {
+                        "usd": 0.5,
+                        "diem": 0.5
+                    }
+                },
+                "availableContextTokens": 40000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemma 3 27B running in a Trusted Execution Environment (TEE). Google's multimodal model supporting vision-language input with 140+ language understanding, with hardware attestation evidence available for independent verification.",
+                "name": "Gemma 3 27B",
+                "modelSource": "https://huggingface.co/google/gemma-3-27b-it",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 64000,
+            "created": 1779580800,
+            "id": "e2ee-gemma-4-26b-a4b-uncensored-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.19,
+                        "diem": 0.19
+                    },
+                    "output": {
+                        "usd": 0.88,
+                        "diem": 0.88
+                    }
+                },
+                "availableContextTokens": 64000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemma 4 26B A4B Uncensored running in a Trusted Execution Environment (TEE). An uncensored variant of Google's Gemma 4 MoE model with 25.2B total / 3.8B active parameters, supporting multimodal input across text and images, with hardware attestation evidence available for independent verification.",
+                "name": "Gemma 4 26B A4B Uncensored",
+                "modelSource": "https://www.redpill.ai/models/phala/gemma-4-26b-a4b-uncensored",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 524288,
+            "created": 1781568000,
+            "id": "e2ee-glm-5-2-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.75,
+                        "diem": 1.75
+                    },
+                    "output": {
+                        "usd": 5.75,
+                        "diem": 5.75
+                    }
+                },
+                "availableContextTokens": 524288,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM 5.2 running in a Trusted Execution Environment (TEE). Z.AI's flagship model for long-horizon tasks with enhanced reasoning and project-level engineering context, with hardware attestation evidence available for independent verification.",
+                "name": "GLM 5.2",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5.2",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1773792000,
+            "id": "e2ee-gpt-oss-20b-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.05,
+                        "diem": 0.05
+                    },
+                    "output": {
+                        "usd": 0.19,
+                        "diem": 0.19
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT OSS 20B running in a Trusted Execution Environment (TEE). OpenAI's compact open-weight 21B MoE model with 3.6B active parameters, optimized for lower-latency inference, with hardware attestation evidence available for independent verification.",
+                "name": "GPT OSS 20B",
+                "modelSource": "https://huggingface.co/openai/gpt-oss-20b",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1773792000,
+            "id": "e2ee-gpt-oss-120b-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.13,
+                        "diem": 0.13
+                    },
+                    "output": {
+                        "usd": 0.65,
+                        "diem": 0.65
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": true,
+                    "reasoningEffortOptions": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high"
+                    ],
+                    "defaultReasoningEffort": "low",
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GPT OSS 120B running in a Trusted Execution Environment (TEE). OpenAI's open-weight 117B-parameter MoE model with configurable reasoning depth and native tool use, with hardware attestation evidence available for independent verification.",
+                "name": "GPT OSS 120B",
+                "modelSource": "https://huggingface.co/openai/gpt-oss-120b",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 32000,
+            "created": 1773792000,
+            "id": "e2ee-qwen-2-5-7b-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.05,
+                        "diem": 0.05
+                    },
+                    "output": {
+                        "usd": 0.13,
+                        "diem": 0.13
+                    }
+                },
+                "availableContextTokens": 32000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen 2.5 7B Instruct running in a Trusted Execution Environment (TEE). A compact model with strong coding, math, and multilingual capabilities supporting 29+ languages, with hardware attestation evidence available for independent verification.",
+                "name": "Qwen 2.5 7B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1779580800,
+            "id": "e2ee-qwen3-6-35b-a3b-uncensored-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.38,
+                        "diem": 0.38
+                    },
+                    "output": {
+                        "usd": 1.88,
+                        "diem": 1.88
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen3.6 35B A3B Uncensored running in a Trusted Execution Environment (TEE). An uncensored variant of Alibaba's Qwen3.6 MoE model with 35B total parameters and ~3B active, supporting 262K context and multimodal input across text, images, and video, with hardware attestation evidence available for independent verification.",
+                "name": "Qwen3.6 35B A3B Uncensored",
+                "modelSource": "https://www.redpill.ai/models/phala/qwen3.6-35b-a3b-uncensored",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 128000,
+            "created": 1773792000,
+            "id": "e2ee-qwen3-vl-30b-a3b-p",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.25,
+                        "diem": 0.25
+                    },
+                    "output": {
+                        "usd": 0.9,
+                        "diem": 0.9
+                    }
+                },
+                "availableContextTokens": 128000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": false,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": true,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen3 VL 30B A3B running in a Trusted Execution Environment (TEE). A multimodal model unifying text generation with visual understanding for images and videos, with hardware attestation evidence available for independent verification.",
+                "name": "Qwen3 VL 30B A3B",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 200000,
+            "created": 1776988800,
+            "id": "e2ee-glm-5-1",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 1.1,
+                        "diem": 1.1
+                    },
+                    "output": {
+                        "usd": 4.15,
+                        "diem": 4.15
+                    }
+                },
+                "model_sets": [
+                    "venice_recommendations"
+                ],
+                "availableContextTokens": 200000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "GLM 5.1 running in a Trusted Execution Environment (TEE). Hardware attestation evidence is available for independent verification of enclave identity and configuration.",
+                "name": "GLM 5.1",
+                "modelSource": "https://huggingface.co/zai-org/GLM-5.1",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 32000,
+            "created": 1779235200,
+            "id": "e2ee-qwen3-6-35b-a3b",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.182,
+                        "diem": 0.182
+                    },
+                    "cache_input": {
+                        "usd": 0.06,
+                        "diem": 0.06
+                    },
+                    "output": {
+                        "usd": 1.18,
+                        "diem": 1.18
+                    }
+                },
+                "availableContextTokens": 32000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen 3.6 35B A3B FP8 running in a Trusted Execution Environment (TEE). A fast mixture-of-experts model with ~3B active parameters per token. Hardware attestation evidence is available for independent verification of enclave identity and configuration.",
+                "name": "Qwen 3.6 35B A3B FP8",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 256000,
+            "created": 1783382400,
+            "id": "e2ee-qwen3-6-27b",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.346,
+                        "diem": 0.346
+                    },
+                    "cache_input": {
+                        "usd": 0.171,
+                        "diem": 0.171
+                    },
+                    "output": {
+                        "usd": 3.46,
+                        "diem": 3.46
+                    }
+                },
+                "availableContextTokens": 256000,
+                "maxCompletionTokens": 32768,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Qwen 3.6 27B FP8 running in a Trusted Execution Environment (TEE). Hardware attestation evidence is available for independent verification of enclave identity and configuration.",
+                "name": "Qwen 3.6 27B FP8",
+                "modelSource": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 32000,
+            "created": 1779235200,
+            "id": "e2ee-gemma-4-31b",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.139,
+                        "diem": 0.139
+                    },
+                    "cache_input": {
+                        "usd": 0.028,
+                        "diem": 0.028
+                    },
+                    "output": {
+                        "usd": 0.43,
+                        "diem": 0.43
+                    }
+                },
+                "availableContextTokens": 32000,
+                "maxCompletionTokens": 4096,
+                "capabilities": {
+                    "optimizedForCode": false,
+                    "quantization": "not-available",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": false,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "Gemma 4 31B Instruct running in a Trusted Execution Environment (TEE). Hardware attestation evidence is available for independent verification of enclave identity and configuration.",
+                "name": "Gemma 4 31B Instruct",
+                "modelSource": "https://huggingface.co/google/gemma-4-31B-it",
+                "offline": false,
+                "privacy": "private",
+                "traits": []
+            },
+            "object": "model",
+            "owned_by": "venice.ai",
+            "type": "text"
+        },
+        {
+            "context_length": 1000000,
+            "created": 1783382400,
+            "id": "e2ee-deepseek-v4-flash",
+            "model_spec": {
+                "betaModel": true,
+                "pricing": {
+                    "input": {
+                        "usd": 0.182,
+                        "diem": 0.182
+                    },
+                    "cache_input": {
+                        "usd": 0.038,
+                        "diem": 0.038
+                    },
+                    "output": {
+                        "usd": 0.373,
+                        "diem": 0.373
+                    }
+                },
+                "availableContextTokens": 1000000,
+                "maxCompletionTokens": 8192,
+                "capabilities": {
+                    "optimizedForCode": true,
+                    "quantization": "fp8",
+                    "supportsAudioInput": false,
+                    "supportsFunctionCalling": true,
+                    "supportsLogProbs": false,
+                    "supportsMultipleImages": false,
+                    "supportsReasoning": true,
+                    "supportsReasoningEffort": false,
+                    "supportsResponseSchema": false,
+                    "supportsTeeAttestation": true,
+                    "supportsE2EE": true,
+                    "supportsVideoInput": false,
+                    "supportsVision": false,
+                    "supportsWebSearch": true,
+                    "supportsXSearch": false
+                },
+                "description": "DeepSeek V4 Flash running in a Trusted Execution Environment (TEE). Hardware attestation evidence is available for independent verification of enclave identity and configuration.",
+                "name": "DeepSeek V4 Flash",
+                "modelSource": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
                 "offline": false,
                 "privacy": "private",
                 "traits": []

--- a/internal/json/unmarshal.go
+++ b/internal/json/unmarshal.go
@@ -1,0 +1,184 @@
+// Package json provides helpers for decoding LLM-produced JSON that may be truncated.
+package json
+
+import (
+	stdjson "encoding/json"
+	"strings"
+)
+
+// Unmarshal decodes data into v like encoding/json.Unmarshal.
+// If the first decode fails, it attempts to repair truncated JSON and retries.
+// repaired is true when the successful decode used a repaired payload.
+func Unmarshal(data []byte, v any) (repaired bool, err error) {
+	if err := stdjson.Unmarshal(data, v); err == nil {
+		return false, nil
+	} else {
+		repairedTxt := repairTruncated(string(data))
+		if repairedTxt == "" {
+			return false, err
+		}
+		if err2 := stdjson.Unmarshal([]byte(repairedTxt), v); err2 == nil {
+			return true, nil
+		}
+		return false, err
+	}
+}
+
+// repairTruncated attempts to make truncated JSON parseable by closing open
+// strings/structures and dropping incomplete trailing keys or values.
+func repairTruncated(s string) string {
+	s = strings.TrimRight(s, " \t\r\n")
+	if s == "" {
+		return s
+	}
+
+	inString, _ := scanState(s)
+	if inString {
+		if endsWithEscapedBackslash(s) {
+			s = s[:len(s)-1]
+		}
+		s += `"`
+	}
+
+	for {
+		s = strings.TrimRight(s, " \t\r\n")
+		if s == "" {
+			return s
+		}
+		inString, _ = scanState(s)
+		if inString {
+			break
+		}
+
+		if strings.HasSuffix(s, ",") {
+			s = s[:len(s)-1]
+			continue
+		}
+
+		if strings.HasSuffix(s, ":") {
+			s = strings.TrimRight(s[:len(s)-1], " \t\r\n")
+			s = trimTrailingString(s)
+			s = strings.TrimRight(s, " \t\r\n")
+			if strings.HasSuffix(s, ",") {
+				s = s[:len(s)-1]
+			}
+			continue
+		}
+
+		before, ok := splitTrailingString(s)
+		if !ok {
+			break
+		}
+		beforeTrimmed := strings.TrimRight(before, " \t\r\n")
+		if strings.HasSuffix(beforeTrimmed, ":") {
+			break
+		}
+		if strings.HasSuffix(beforeTrimmed, ",") || strings.HasSuffix(beforeTrimmed, "{") {
+			s = beforeTrimmed
+			if strings.HasSuffix(s, ",") {
+				s = s[:len(s)-1]
+			}
+			continue
+		}
+		break
+	}
+
+	s = strings.TrimRight(s, " \t\r\n")
+	_, stack := scanState(s)
+	var b strings.Builder
+	b.Grow(len(s) + len(stack))
+	b.WriteString(s)
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i] == '{' {
+			b.WriteByte('}')
+		} else {
+			b.WriteByte(']')
+		}
+	}
+	return b.String()
+}
+
+func scanState(s string) (inString bool, stack []byte) {
+	escape := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{', '[':
+			stack = append(stack, c)
+		case '}':
+			if len(stack) > 0 && stack[len(stack)-1] == '{' {
+				stack = stack[:len(stack)-1]
+			}
+		case ']':
+			if len(stack) > 0 && stack[len(stack)-1] == '[' {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	return inString, stack
+}
+
+func endsWithEscapedBackslash(s string) bool {
+	n := 0
+	for i := len(s) - 1; i >= 0 && s[i] == '\\'; i-- {
+		n++
+	}
+	return n%2 == 1
+}
+
+func splitTrailingString(s string) (before string, ok bool) {
+	if !strings.HasSuffix(s, `"`) {
+		return "", false
+	}
+	i := len(s) - 2
+	for i >= 0 {
+		if s[i] != '\\' {
+			break
+		}
+		i--
+	}
+	bs := len(s) - 2 - i
+	if bs%2 == 1 {
+		return "", false
+	}
+	for j := len(s) - 2; j >= 0; j-- {
+		if s[j] != '"' {
+			continue
+		}
+		k := j - 1
+		esc := 0
+		for k >= 0 && s[k] == '\\' {
+			esc++
+			k--
+		}
+		if esc%2 == 1 {
+			continue
+		}
+		return s[:j], true
+	}
+	return "", false
+}
+
+func trimTrailingString(s string) string {
+	before, ok := splitTrailingString(s)
+	if !ok {
+		return s
+	}
+	return before
+}

--- a/internal/json/unmarshal.go
+++ b/internal/json/unmarshal.go
@@ -50,8 +50,8 @@ func repairTruncated(s string) string {
 			break
 		}
 
-		if strings.HasSuffix(s, ",") {
-			s = s[:len(s)-1]
+		if trimmed := strings.TrimSuffix(s, ","); trimmed != s {
+			s = trimmed
 			continue
 		}
 
@@ -59,9 +59,7 @@ func repairTruncated(s string) string {
 			s = strings.TrimRight(s[:len(s)-1], " \t\r\n")
 			s = trimTrailingString(s)
 			s = strings.TrimRight(s, " \t\r\n")
-			if strings.HasSuffix(s, ",") {
-				s = s[:len(s)-1]
-			}
+			s = strings.TrimSuffix(s, ",")
 			continue
 		}
 
@@ -74,10 +72,7 @@ func repairTruncated(s string) string {
 			break
 		}
 		if strings.HasSuffix(beforeTrimmed, ",") || strings.HasSuffix(beforeTrimmed, "{") {
-			s = beforeTrimmed
-			if strings.HasSuffix(s, ",") {
-				s = s[:len(s)-1]
-			}
+			s = strings.TrimSuffix(beforeTrimmed, ",")
 			continue
 		}
 		break

--- a/internal/json/unmarshal_test.go
+++ b/internal/json/unmarshal_test.go
@@ -1,0 +1,127 @@
+package json
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jwebster45206/story-engine/pkg/conditionals"
+)
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	truncatedAcquire := `{
+  "game_ended": false,
+  "item_events": [
+    {
+      "action": "acquire",
+      "consumed": false,
+      "from": { "name": "black_pearl", "type": "location" },
+      "item": "ship repair ledger"` + strings.Repeat("\n", 40)
+
+	tests := []struct {
+		name         string
+		input        string
+		wantErr      bool
+		wantRepaired bool
+		wantLocation string
+		wantEnded    *bool
+		wantItems    int
+		wantItemName string
+	}{
+		{
+			name:         "truncated item_events acquire with newline padding",
+			input:        truncatedAcquire,
+			wantRepaired: true,
+			wantItems:    1,
+			wantItemName: "ship repair ledger",
+			wantEnded:    boolPtr(false),
+		},
+		{
+			name:         "truncated mid-string value",
+			input:        `{"user_location": "crash_bea`,
+			wantRepaired: true,
+			wantLocation: "crash_bea",
+		},
+		{
+			name:         "trailing comma before EOF",
+			input:        `{"user_location": "dock", "game_ended": false,`,
+			wantRepaired: true,
+			wantLocation: "dock",
+			wantEnded:    boolPtr(false),
+		},
+		{
+			name:         "truncated after key with no value",
+			input:        `{"user_location": "dock", "set_vars":`,
+			wantRepaired: true,
+			wantLocation: "dock",
+		},
+		{
+			name:         "already-valid JSON",
+			input:        `{"user_location":"dock","game_ended":false,"item_events":[],"npc_events":[],"set_vars":{}}`,
+			wantRepaired: false,
+			wantLocation: "dock",
+			wantEnded:    boolPtr(false),
+		},
+		{
+			name:    "unrepairable garbage",
+			input:   `not json at all`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var delta conditionals.GameStateDelta
+			repaired, err := Unmarshal([]byte(tt.input), &delta)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got repaired=%v", repaired)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if repaired != tt.wantRepaired {
+				t.Fatalf("repaired=%v, want %v", repaired, tt.wantRepaired)
+			}
+			if tt.wantLocation != "" && delta.UserLocation != tt.wantLocation {
+				t.Errorf("user_location=%q, want %q", delta.UserLocation, tt.wantLocation)
+			}
+			if tt.wantEnded != nil {
+				if delta.GameEnded == nil || *delta.GameEnded != *tt.wantEnded {
+					t.Errorf("game_ended=%v, want %v", delta.GameEnded, *tt.wantEnded)
+				}
+			}
+			if tt.wantItems > 0 {
+				if len(delta.ItemEvents) != tt.wantItems {
+					t.Fatalf("item_events len=%d, want %d", len(delta.ItemEvents), tt.wantItems)
+				}
+				if tt.wantItemName != "" && delta.ItemEvents[0].Item != tt.wantItemName {
+					t.Errorf("item=%q, want %q", delta.ItemEvents[0].Item, tt.wantItemName)
+				}
+				if delta.ItemEvents[0].Action != "acquire" {
+					t.Errorf("action=%q, want acquire", delta.ItemEvents[0].Action)
+				}
+			}
+		})
+	}
+}
+
+func TestRepairTruncated(t *testing.T) {
+	t.Parallel()
+
+	got := repairTruncated(`{"a": true,`)
+	if got != `{"a": true}` {
+		t.Fatalf("got %q", got)
+	}
+
+	got = repairTruncated(`{"loc": "ab`)
+	if got != `{"loc": "ab"}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/services/anthropic.go
+++ b/internal/services/anthropic.go
@@ -394,9 +394,16 @@ func (a *AnthropicService) DeltaUpdate(ctx context.Context, messages []chat.Chat
 		return nil, "", err
 	}
 
-	deltaUpdate, err := parseDeltaUpdateResponse(content)
+	deltaUpdate, repaired, err := parseDeltaUpdateResponse(content)
 	if err != nil {
 		return nil, "", err
+	}
+	if repaired {
+		a.logger.Warn("fixed truncated gamestate delta JSON",
+			"backend_model", modelToUse,
+			"original_len", len(content),
+			"preview", content,
+		)
 	}
 
 	return deltaUpdate, modelToUse, nil

--- a/internal/services/llm.go
+++ b/internal/services/llm.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	sejson "github.com/jwebster45206/story-engine/internal/json"
 	"github.com/jwebster45206/story-engine/pkg/chat"
 	"github.com/jwebster45206/story-engine/pkg/conditionals"
 	"github.com/jwebster45206/story-engine/pkg/state"
@@ -57,9 +58,11 @@ type LLMService interface {
 // parseDeltaUpdateResponse parses an LLM response text into a DeltaUpdate struct.
 // It handles various response formats including markdown code blocks, mixed content,
 // and other common artifacts that LLMs might include in their JSON responses.
-func parseDeltaUpdateResponse(responseText string) (*conditionals.GameStateDelta, error) {
+// When the JSON is truncated, it attempts to salvage complete fields and returns
+// repaired=true if salvage succeeded.
+func parseDeltaUpdateResponse(responseText string) (*conditionals.GameStateDelta, bool, error) {
 	if responseText == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	originalText := responseText
@@ -111,9 +114,10 @@ func parseDeltaUpdateResponse(responseText string) (*conditionals.GameStateDelta
 	mTxt = strings.TrimSpace(mTxt)
 
 	var metaUpdate conditionals.GameStateDelta
-	if err := json.Unmarshal([]byte(mTxt), &metaUpdate); err != nil {
-		return nil, fmt.Errorf("failed to parse gamestate delta. Original response: %q, Cleaned text: %q, Error: %w", originalText, mTxt, err)
+	repaired, err := sejson.Unmarshal([]byte(mTxt), &metaUpdate)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse gamestate delta. Original response: %q, Cleaned text: %q, Error: %w", originalText, mTxt, err)
 	}
 
-	return &metaUpdate, nil
+	return &metaUpdate, repaired, nil
 }

--- a/internal/services/llm_parse_test.go
+++ b/internal/services/llm_parse_test.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDeltaUpdateResponse_Empty(t *testing.T) {
+	t.Parallel()
+	delta, repaired, err := parseDeltaUpdateResponse("")
+	if err != nil || repaired || delta != nil {
+		t.Fatalf("delta=%v repaired=%v err=%v", delta, repaired, err)
+	}
+}
+
+func TestParseDeltaUpdateResponse_MarkdownAndRepair(t *testing.T) {
+	t.Parallel()
+	input := "```json\n{\"user_location\": \"dock\", \"game_ended\": false,\n```"
+	delta, repaired, err := parseDeltaUpdateResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !repaired {
+		t.Fatal("expected repaired=true")
+	}
+	if delta == nil || delta.UserLocation != "dock" {
+		t.Fatalf("unexpected delta: %+v", delta)
+	}
+}
+
+func TestParseDeltaUpdateResponse_TruncatedAcquire(t *testing.T) {
+	t.Parallel()
+	input := `{
+  "game_ended": false,
+  "item_events": [
+    {
+      "action": "acquire",
+      "consumed": false,
+      "from": { "name": "black_pearl", "type": "location" },
+      "item": "ship repair ledger"` + strings.Repeat("\n", 20)
+	delta, repaired, err := parseDeltaUpdateResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !repaired {
+		t.Fatal("expected repaired=true")
+	}
+	if delta == nil || len(delta.ItemEvents) != 1 || delta.ItemEvents[0].Item != "ship repair ledger" {
+		t.Fatalf("unexpected delta: %+v", delta)
+	}
+}

--- a/internal/services/venice.go
+++ b/internal/services/venice.go
@@ -341,9 +341,16 @@ func (v *VeniceService) DeltaUpdate(ctx context.Context, messages []chat.ChatMes
 		return nil, "", err
 	}
 
-	deltaUpdate, err := parseDeltaUpdateResponse(content)
+	deltaUpdate, repaired, err := parseDeltaUpdateResponse(content)
 	if err != nil {
 		return nil, "", err
+	}
+	if repaired {
+		v.logger.Warn("fixed truncated gamestate delta JSON",
+			"backend_model", modelToUse,
+			"original_len", len(content),
+			"preview", content,
+		)
 	}
 
 	return deltaUpdate, modelToUse, nil


### PR DESCRIPTION
## Summary
- Add `internal/json.Unmarshal` that repairs truncated LLM JSON (close open structures, drop incomplete trailing keys) and retries decode
- Wire Venice and Anthropic delta extraction through the shared parser; on salvage, warn with `fixed truncated gamestate delta JSON` and still apply the delta
- Cover truncated acquire/newline-pad, mid-string, trailing comma, incomplete keys, and markdown-wrapped payloads in unit tests

## Test plan
- [ ] `go test ./internal/json/ ./internal/services/`
- [ ] Trigger a Venice backend delta that historically returned newline-padded truncated JSON; confirm sync completes and a warn log appears
- [ ] Confirm valid delta JSON still parses with `repaired=false` (no warn)
- [ ] Smoke a normal console turn (move/acquire) end-to-end with Venice provider


Made with [Cursor](https://cursor.com)