### PR TITLE
fix: always mount config.docker.json in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,22 +180,18 @@ CONFIG=config.json go run ./cmd/worker
 
 ### Docker Compose
 
-Defaults to `./data` and `./config.docker.json`. Override either when starting compose. Host `CONFIG` is mounted read-only at `/app/config.json`:
-
 ```bash
-# Default
+# Default: ./data and ./config.docker.json
 docker compose up --build -d
 
-# Custom data dir and config
-DATA_DIR=~/Documents/story-engine-scenarios \
-CONFIG=./config.venice.json \
-docker compose up --build -d
+# Custom data directory
+DATA_DIR=~/Documents/story-engine-scenarios docker compose up --build -d
 ```
 
-Edit the mounted config on the host, then recreate the containers so the mount picks up the change (a plain `restart` can keep a stale file bind):
+Edit `config.docker.json` on the host, then restart to reload:
 
 ```bash
-docker compose up -d --force-recreate story-engine-api story-engine-worker
+docker compose restart story-engine-api story-engine-worker
 ```
 
 Use `redis:6379` as `redis_url` in Docker configs (the compose Redis service hostname).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - "8080:8080"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
+      - ./config.docker.json:/app/config.docker.json
     environment:
-      - CONFIG=/app/config.json
+      - CONFIG=/app/config.docker.json
     depends_on:
       - redis
     healthcheck:
@@ -30,9 +30,9 @@ services:
     command: ["./worker"]  # Override CMD
     volumes:
       - ${DATA_DIR:-./data}:/app/data
-      - ${CONFIG:-./config.docker.json}:/app/config.json:ro
+      - ./config.docker.json:/app/config.docker.json
     environment:
-      - CONFIG=/app/config.json
+      - CONFIG=/app/config.docker.json
       - WORKER_ID=worker-1
     depends_on:
       - redis


### PR DESCRIPTION
## Summary
- Mount `./config.docker.json` at a fixed path for api and worker (no host `CONFIG` override)
- Keep `DATA_DIR` override; document restart after editing `config.docker.json`


Made with [Cursor](https://cursor.com)